### PR TITLE
feat: add command palette and status bar

### DIFF
--- a/src/app/core/hooks/useAutosave.ts
+++ b/src/app/core/hooks/useAutosave.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { useAppState } from '../state/store';
 
 /**
  * Simple autosave hook that stores a value in localStorage after a delay.
@@ -7,14 +8,16 @@ import { useEffect } from 'react';
  * @param delay Debounce delay in milliseconds
  */
 export default function useAutosave(key: string, value: string, delay = 1000) {
+  const setLastSaved = useAppState((s) => s.setLastSaved);
   useEffect(() => {
     const handler = setTimeout(() => {
       try {
         localStorage.setItem(key, value);
+        setLastSaved(Date.now());
       } catch {
         // ignore write errors
       }
     }, delay);
     return () => clearTimeout(handler);
-  }, [key, value, delay]);
+  }, [key, value, delay, setLastSaved]);
 }

--- a/src/app/core/hooks/useHotkeys.ts
+++ b/src/app/core/hooks/useHotkeys.ts
@@ -1,0 +1,28 @@
+import { useEffect } from 'react';
+
+type HotkeyHandler = (event: KeyboardEvent) => void;
+type HotkeyMap = Record<string, HotkeyHandler>;
+
+const isMac = typeof navigator !== 'undefined' && /mac/i.test(navigator.platform);
+
+/**
+ * Simple hotkey hook that listens for keyboard shortcuts like ctrl+s.
+ * Pass an object where the keys are in the format "ctrl+k".
+ */
+export default function useHotkeys(map: HotkeyMap) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const key = e.key.toLowerCase();
+      const ctrl = e.ctrlKey || (isMac && e.metaKey);
+      const combo = `ctrl+${key}`;
+      const fn = map[combo];
+      if (ctrl && fn) {
+        e.preventDefault();
+        fn(e);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [map]);
+}
+

--- a/src/app/core/state/store.tsx
+++ b/src/app/core/state/store.tsx
@@ -1,12 +1,22 @@
 import React, { createContext, useContext, ReactNode, useMemo } from 'react';
 import create, { StoreApi } from 'zustand';
 
-interface AppState {}
+interface AppState {
+  lastSaved: number | null;
+  setLastSaved: (ts: number) => void;
+}
 
 const AppStateContext = createContext<StoreApi<AppState> | null>(null);
 
 export const AppStateProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const store = useMemo(() => create<AppState>(() => ({})), []);
+  const store = useMemo(
+    () =>
+      create<AppState>((set) => ({
+        lastSaved: null,
+        setLastSaved: (ts) => set({ lastSaved: ts }),
+      })),
+    [],
+  );
   return <AppStateContext.Provider value={store}>{children}</AppStateContext.Provider>;
 };
 

--- a/src/app/core/ui/CommandPalette.tsx
+++ b/src/app/core/ui/CommandPalette.tsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+const commands = [
+  { label: 'Editor', path: '/editor' },
+  { label: 'Book', path: '/book' },
+  { label: 'Characters', path: '/characters' },
+  { label: 'World', path: '/world' },
+  { label: 'Plot', path: '/plot' },
+  { label: 'Magic', path: '/magic' },
+  { label: 'Tech', path: '/tech' },
+  { label: 'Timeline', path: '/timeline' },
+  { label: 'Relationships', path: '/relationships' },
+];
+
+const CommandPalette: React.FC<Props> = ({ open, onClose }) => {
+  const [query, setQuery] = useState('');
+  const navigate = useNavigate();
+  const filtered = commands.filter((c) =>
+    c.label.toLowerCase().includes(query.toLowerCase()),
+  );
+  if (!open) return null;
+
+  const handleSelect = (path: string) => {
+    navigate(path);
+    onClose();
+    setQuery('');
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/50 flex items-start justify-center">
+      <div className="mt-20 w-96 rounded bg-white shadow dark:bg-gray-800">
+        <input
+          autoFocus
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Buscar..."
+          className="w-full border-b p-2 bg-transparent outline-none"
+        />
+        <ul className="max-h-64 overflow-auto">
+          {filtered.map((c) => (
+            <li key={c.path}>
+              <button
+                className="w-full p-2 text-left hover:bg-gray-100 dark:hover:bg-gray-700"
+                onClick={() => handleSelect(c.path)}
+              >
+                {c.label}
+              </button>
+            </li>
+          ))}
+          {filtered.length === 0 && (
+            <li className="p-2 text-sm text-gray-500">Nenhum resultado</li>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+};
+
+export default CommandPalette;
+

--- a/src/app/core/ui/StatusBar.tsx
+++ b/src/app/core/ui/StatusBar.tsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { useAppState } from '../state/store';
+
+interface Props {
+  wordCount?: number;
+}
+
+const StatusBar: React.FC<Props> = ({ wordCount }) => {
+  const lastSaved = useAppState((s) => s.lastSaved);
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    const update = () => {
+      if (!lastSaved) {
+        setText('Nunca salvo');
+        return;
+      }
+      const diff = Math.floor((Date.now() - lastSaved) / 1000);
+      setText(`Salvo há ${diff}s`);
+    };
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [lastSaved]);
+
+  return (
+    <footer className="border-t px-4 py-1 text-sm flex justify-between bg-gray-50 dark:bg-gray-900">
+      <span>{wordCount != null ? `${wordCount} palavras` : ''}</span>
+      <span>{text}</span>
+    </footer>
+  );
+};
+
+export default StatusBar;
+

--- a/src/app/layout/Sidebar.tsx
+++ b/src/app/layout/Sidebar.tsx
@@ -1,22 +1,58 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { NavLink } from 'react-router-dom';
+import {
+  Menu,
+  FileText,
+  Book,
+  Users,
+  Globe,
+  Zap,
+  Cpu,
+  Clock,
+  Share2,
+} from 'lucide-react';
 
-const Sidebar: React.FC = () => (
-  <aside className="w-48 bg-gray-100 p-4">
-    <nav>
-      <ul className="space-y-2">
-        <li><NavLink to="/editor">Editor</NavLink></li>
-        <li><NavLink to="/book">Book</NavLink></li>
-        <li><NavLink to="/characters">Characters</NavLink></li>
-        <li><NavLink to="/world">World</NavLink></li>
-        <li><NavLink to="/plot">Plot</NavLink></li>
-        <li><NavLink to="/magic">Magic</NavLink></li>
-        <li><NavLink to="/tech">Tech</NavLink></li>
-        <li><NavLink to="/timeline">Timeline</NavLink></li>
-        <li><NavLink to="/relationships">Relationships</NavLink></li>
-      </ul>
-    </nav>
-  </aside>
-);
+const links = [
+  { to: '/editor', label: 'Editor', icon: FileText },
+  { to: '/book', label: 'Book', icon: Book },
+  { to: '/characters', label: 'Characters', icon: Users },
+  { to: '/world', label: 'World', icon: Globe },
+  { to: '/plot', label: 'Plot', icon: FileText },
+  { to: '/magic', label: 'Magic', icon: Zap },
+  { to: '/tech', label: 'Tech', icon: Cpu },
+  { to: '/timeline', label: 'Timeline', icon: Clock },
+  { to: '/relationships', label: 'Relationships', icon: Share2 },
+];
+
+const Sidebar: React.FC = () => {
+  const [collapsed, setCollapsed] = useState(false);
+  return (
+    <aside
+      className={`bg-gray-100 p-4 transition-all ${collapsed ? 'w-16' : 'w-48'}`}
+    >
+      <button onClick={() => setCollapsed((c) => !c)} className="mb-4">
+        <Menu size={20} />
+      </button>
+      <nav>
+        <ul className="space-y-2">
+          {links.map(({ to, label, icon: Icon }) => (
+            <li key={to}>
+              <NavLink
+                to={to}
+                className={({ isActive }) =>
+                  `flex items-center gap-2 p-2 rounded hover:bg-gray-200 ${isActive ? 'bg-gray-200 font-bold' : ''}`
+                }
+              >
+                <Icon size={18} />
+                {!collapsed && <span>{label}</span>}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </aside>
+  );
+};
 
 export default Sidebar;
+

--- a/src/app/layout/Topbar.tsx
+++ b/src/app/layout/Topbar.tsx
@@ -1,17 +1,54 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Sun, Moon } from 'lucide-react';
+import CommandPalette from '../core/ui/CommandPalette';
+import useHotkeys from '../core/hooks/useHotkeys';
+import { useAppState } from '../core/state/store';
 
-const Topbar: React.FC = () => (
-  <header className="flex items-center justify-between p-4 border-b">
-    <input
-      type="text"
-      placeholder="Buscar..."
-      className="border p-1 rounded w-1/2"
-    />
-    <div className="space-x-2">
-      <button className="px-3 py-1 bg-blue-500 text-white rounded">Salvar</button>
-      <button className="px-3 py-1 bg-green-500 text-white rounded">Exportar</button>
-    </div>
-  </header>
-);
+const Topbar: React.FC = () => {
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [dark, setDark] = useState(false);
+  const lastSaved = useAppState((s) => s.lastSaved);
+  const [status, setStatus] = useState('');
+
+  useHotkeys({ 'ctrl+k': () => setPaletteOpen(true) });
+
+  useEffect(() => {
+    const update = () => {
+      if (!lastSaved) {
+        setStatus('Nunca salvo');
+        return;
+      }
+      const diff = Math.floor((Date.now() - lastSaved) / 1000);
+      setStatus(`Salvo há ${diff}s`);
+    };
+    update();
+    const id = setInterval(update, 1000);
+    return () => clearInterval(id);
+  }, [lastSaved]);
+
+  const toggleTheme = () => {
+    setDark((d) => !d);
+    document.documentElement.classList.toggle('dark');
+  };
+
+  return (
+    <header className="flex items-center justify-between p-4 border-b">
+      <input
+        type="text"
+        placeholder="Buscar..."
+        onFocus={() => setPaletteOpen(true)}
+        className="border p-1 rounded w-1/2"
+      />
+      <div className="flex items-center space-x-4">
+        <span className="text-sm">{status}</span>
+        <button onClick={toggleTheme} className="p-2 rounded hover:bg-gray-200">
+          {dark ? <Sun size={16} /> : <Moon size={16} />}
+        </button>
+      </div>
+      <CommandPalette open={paletteOpen} onClose={() => setPaletteOpen(false)} />
+    </header>
+  );
+};
 
 export default Topbar;
+

--- a/src/modules/editor/pages/EditorPage.tsx
+++ b/src/modules/editor/pages/EditorPage.tsx
@@ -6,13 +6,24 @@ import WritingArea from '../components/WritingArea';
 import { templates } from '../utils/templates';
 import { exec } from '../utils/formatting';
 import useAutosave from '../../../app/core/hooks/useAutosave';
+import useHotkeys from '../../../app/core/hooks/useHotkeys';
+import StatusBar from '../../../app/core/ui/StatusBar';
+import { useAppState } from '../../../app/core/state/store';
 
 const EditorPage: React.FC = () => {
   const [content, setContent] = useState('');
   const [mode, setMode] = useState<'normal' | 'focus' | 'dark'>('normal');
-  const [showCount, setShowCount] = useState(true);
 
   useAutosave('editor-content', content);
+
+  const setLastSaved = useAppState((s) => s.setLastSaved);
+  useHotkeys({
+    'ctrl+s': () => {
+      localStorage.setItem('editor-content', content);
+      setLastSaved(Date.now());
+    },
+    'ctrl+n': () => setContent(''),
+  });
 
   const wordCount = useMemo(() => {
     return content.trim().split(/\s+/).filter(Boolean).length;
@@ -23,21 +34,20 @@ const EditorPage: React.FC = () => {
   }, []);
 
   const handleInsertTemplate = (key: string) => {
-    setContent(prev => prev + (templates[key] || ''));
+    setContent((prev) => prev + (templates[key] || ''));
   };
 
   return (
-    <div className="space-y-4 p-4">
-      <div className="flex items-center gap-4">
-        <ModeSwitcher mode={mode} onModeChange={setMode} />
-        {showCount && <span>{wordCount} palavras</span>}
-        <button onClick={() => setShowCount(!showCount)}>
-          {showCount ? 'Ocultar' : 'Mostrar'} contagem
-        </button>
+    <div className="flex flex-col h-full">
+      <div className="space-y-4 p-4 flex-1">
+        <div className="flex items-center gap-4">
+          <ModeSwitcher mode={mode} onModeChange={setMode} />
+        </div>
+        <RichToolbar onCommand={handleCommand} />
+        <QuickTemplates onInsert={handleInsertTemplate} />
+        <WritingArea value={content} onChange={setContent} mode={mode} />
       </div>
-      <RichToolbar onCommand={handleCommand} />
-      <QuickTemplates onInsert={handleInsertTemplate} />
-      <WritingArea value={content} onChange={setContent} mode={mode} />
+      <StatusBar wordCount={wordCount} />
     </div>
   );
 };

--- a/src/modules/magic/components/MagicSystemForm.tsx
+++ b/src/modules/magic/components/MagicSystemForm.tsx
@@ -1,0 +1,37 @@
+import React, { useMemo, useState } from 'react';
+import useAutosave from '../../../app/core/hooks/useAutosave';
+import useHotkeys from '../../../app/core/hooks/useHotkeys';
+import StatusBar from '../../../app/core/ui/StatusBar';
+import { useAppState } from '../../../app/core/state/store';
+
+const MagicSystemForm: React.FC = () => {
+  const [description, setDescription] = useState('');
+
+  useAutosave('magic-system', description);
+
+  const setLastSaved = useAppState((s) => s.setLastSaved);
+  useHotkeys({
+    'ctrl+s': () => {
+      localStorage.setItem('magic-system', description);
+      setLastSaved(Date.now());
+    },
+    'ctrl+n': () => setDescription(''),
+  });
+
+  const wordCount = useMemo(() => {
+    return description.trim().split(/\s+/).filter(Boolean).length;
+  }, [description]);
+
+  return (
+    <div className="flex flex-col h-full">
+      <textarea
+        className="flex-1 p-4 border"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <StatusBar wordCount={wordCount} />
+    </div>
+  );
+};
+
+export default MagicSystemForm;

--- a/src/modules/magic/pages/MagicSystemPage.tsx
+++ b/src/modules/magic/pages/MagicSystemPage.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import MagicSystemForm from '../components/MagicSystemForm';
+
+const MagicSystemPage: React.FC = () => <MagicSystemForm />;
+
+export default MagicSystemPage;


### PR DESCRIPTION
## Summary
- add global command palette and status bar components
- enhance layout with collapsible sidebar and autosave-aware topbar
- wire hotkeys and autosave state across editor and magic system pages

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin")*
- `npm run type-check` *(fails: Expected 0 arguments, but got 1 and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ba16ee4b48325bc77bbd5e6af218e