### PR TITLE
feat: add variant and size options to ui components

### DIFF
--- a/src/app/core/ui/Card.tsx
+++ b/src/app/core/ui/Card.tsx
@@ -1,0 +1,36 @@
+
+import React from 'react';
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: string;
+  size?: string;
+  asChild?: boolean;
+}
+
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className = '', variant, size, asChild = false, children, ...props }, ref) => {
+    const classes = [
+      className,
+      variant ? `variant-${variant}` : '',
+      size ? `size-${size}` : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children as React.ReactElement, {
+        className: classes,
+        ref,
+        ...props,
+      });
+    }
+
+    return (
+      <div ref={ref} className={classes} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+Card.displayName = 'Card';

--- a/src/app/core/ui/Input.tsx
+++ b/src/app/core/ui/Input.tsx
@@ -1,0 +1,33 @@
+
+import React from 'react';
+
+export interface InputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  variant?: string;
+  size?: string;
+  asChild?: boolean;
+}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className = '', variant, size, asChild = false, children, ...props }, ref) => {
+    const classes = [
+      className,
+      variant ? `variant-${variant}` : '',
+      size ? `size-${size}` : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children as React.ReactElement, {
+        className: classes,
+        ref,
+        ...props,
+      });
+    }
+
+    return <input ref={ref} className={classes} {...props} />;
+  }
+);
+
+Input.displayName = 'Input';

--- a/src/app/core/ui/Modal.tsx
+++ b/src/app/core/ui/Modal.tsx
@@ -1,0 +1,39 @@
+
+import React from 'react';
+
+export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: string;
+  size?: string;
+  asChild?: boolean;
+  open?: boolean;
+}
+
+export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
+  ({ className = '', variant, size, asChild = false, children, open = true, ...props }, ref) => {
+    if (!open) return null;
+
+    const classes = [
+      className,
+      variant ? `variant-${variant}` : '',
+      size ? `size-${size}` : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children as React.ReactElement, {
+        className: classes,
+        ref,
+        ...props,
+      });
+    }
+
+    return (
+      <div ref={ref} className={classes} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+Modal.displayName = 'Modal';

--- a/src/app/core/ui/Select.tsx
+++ b/src/app/core/ui/Select.tsx
@@ -1,0 +1,37 @@
+
+import React from 'react';
+
+export interface SelectProps
+  extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'size'> {
+  variant?: string;
+  size?: string;
+  asChild?: boolean;
+}
+
+export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className = '', variant, size, asChild = false, children, ...props }, ref) => {
+    const classes = [
+      className,
+      variant ? `variant-${variant}` : '',
+      size ? `size-${size}` : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children as React.ReactElement, {
+        className: classes,
+        ref,
+        ...props,
+      });
+    }
+
+    return (
+      <select ref={ref} className={classes} {...props}>
+        {children}
+      </select>
+    );
+  }
+);
+
+Select.displayName = 'Select';

--- a/src/app/core/ui/Tabs.tsx
+++ b/src/app/core/ui/Tabs.tsx
@@ -1,0 +1,36 @@
+
+import React from 'react';
+
+export interface TabsProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: string;
+  size?: string;
+  asChild?: boolean;
+}
+
+export const Tabs = React.forwardRef<HTMLDivElement, TabsProps>(
+  ({ className = '', variant, size, asChild = false, children, ...props }, ref) => {
+    const classes = [
+      className,
+      variant ? `variant-${variant}` : '',
+      size ? `size-${size}` : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children as React.ReactElement, {
+        className: classes,
+        ref,
+        ...props,
+      });
+    }
+
+    return (
+      <div ref={ref} className={classes} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+Tabs.displayName = 'Tabs';

--- a/src/app/core/ui/Textarea.tsx
+++ b/src/app/core/ui/Textarea.tsx
@@ -1,0 +1,36 @@
+
+import React from 'react';
+
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  variant?: string;
+  size?: string;
+  asChild?: boolean;
+}
+
+export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className = '', variant, size, asChild = false, children, ...props }, ref) => {
+    const classes = [
+      className,
+      variant ? `variant-${variant}` : '',
+      size ? `size-${size}` : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children as React.ReactElement, {
+        className: classes,
+        ref,
+        ...props,
+      });
+    }
+
+    return (
+      <textarea ref={ref} className={classes} {...props}>
+        {children}
+      </textarea>
+    );
+  }
+);
+
+Textarea.displayName = 'Textarea';

--- a/src/app/core/ui/Toolbar.tsx
+++ b/src/app/core/ui/Toolbar.tsx
@@ -1,0 +1,36 @@
+
+import React from 'react';
+
+export interface ToolbarProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: string;
+  size?: string;
+  asChild?: boolean;
+}
+
+export const Toolbar = React.forwardRef<HTMLDivElement, ToolbarProps>(
+  ({ className = '', variant, size, asChild = false, children, ...props }, ref) => {
+    const classes = [
+      className,
+      variant ? `variant-${variant}` : '',
+      size ? `size-${size}` : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(children as React.ReactElement, {
+        className: classes,
+        ref,
+        ...props,
+      });
+    }
+
+    return (
+      <div ref={ref} className={classes} {...props}>
+        {children}
+      </div>
+    );
+  }
+);
+
+Toolbar.displayName = 'Toolbar';


### PR DESCRIPTION
## Summary
- extend Card, Input, Modal, Select, Tabs, Textarea and Toolbar with `variant`, `size` and `asChild` props
- handle `asChild` rendering by cloning child elements
- expose optional `open` prop for Modal

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin" and install attempt returned 403)*
- `npm run type-check` *(fails: multiple TypeScript errors in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_689ba0cf57bc8325897dc8e60c612e7b