### PR TITLE
feat: add feedback ui components

### DIFF
--- a/src/core/ui/EmptyState.tsx
+++ b/src/core/ui/EmptyState.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+interface EmptyStateProps {
+  message: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+const EmptyState: React.FC<EmptyStateProps> = ({ message, actionLabel, onAction }) => (
+  <div className="text-center py-10">
+    <div className="text-4xl mb-4">📭</div>
+    <p className="text-gray-600 mb-4">{message}</p>
+    {actionLabel && onAction && (
+      <button onClick={onAction} className="bg-blue-600 text-white px-4 py-2 rounded">
+        {actionLabel}
+      </button>
+    )}
+  </div>
+);
+
+export default EmptyState;

--- a/src/core/ui/Skeleton.tsx
+++ b/src/core/ui/Skeleton.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface SkeletonProps {
+  className?: string;
+}
+
+const Skeleton: React.FC<SkeletonProps> = ({ className }) => (
+  <div className={`animate-pulse bg-gray-300 rounded ${className}`} />
+);
+
+export default Skeleton;

--- a/src/core/ui/Toast.tsx
+++ b/src/core/ui/Toast.tsx
@@ -1,0 +1,50 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface Toast {
+  id: number;
+  type: 'success' | 'error';
+  message: string;
+}
+
+interface ToastContextValue {
+  addToast: (toast: Omit<Toast, 'id'>) => void;
+}
+
+const ToastContext = createContext<ToastContextValue>({ addToast: () => {} });
+
+export const ToastProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const removeToast = (id: number) => {
+    setToasts(prev => prev.filter(t => t.id !== id));
+  };
+
+  const addToast = (toast: Omit<Toast, 'id'>) => {
+    const id = Date.now();
+    setToasts(prev => [...prev, { ...toast, id }]);
+    setTimeout(() => removeToast(id), 3000);
+  };
+
+  return (
+    <ToastContext.Provider value={{ addToast }}>
+      {children}
+      <div className="fixed bottom-4 right-4 space-y-2 z-50">
+        {toasts.map(t => (
+          <div
+            key={t.id}
+            className={`px-4 py-2 rounded text-white shadow-lg ${
+              t.type === 'success' ? 'bg-green-600' : 'bg-red-600'
+            }`}
+          >
+            {t.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => useContext(ToastContext);
+
+export default ToastProvider;
+

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,13 +5,16 @@ import App from './app/App';
 import "./styles/tokens.css";
 import "./styles/globals.css";
 import { ThemeProvider } from "./app/core/ui/ThemeProvider";
+import { ToastProvider } from './core/ui/Toast';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   
   <React.StrictMode>
     <BrowserRouter>
     <ThemeProvider>
-      <App />
+      <ToastProvider>
+        <App />
+      </ToastProvider>
       </ThemeProvider>
     </BrowserRouter>
   </React.StrictMode>

--- a/src/modules/timeline/pages/TimelinePage.tsx
+++ b/src/modules/timeline/pages/TimelinePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import {
   TimelineWorldHistoryManager,
@@ -18,11 +18,22 @@ import {
   updateEvent,
   deleteEvent,
 } from '../services/timelineRepository';
+import Skeleton from '../../../core/ui/Skeleton';
+import EmptyState from '../../../core/ui/EmptyState';
+import { useToast } from '../../../core/ui/Toast';
 
 const TimelinePage: React.FC = () => {
-  const [eras, setEras] = useState<Era[]>(() => getEras());
-  const [events, setEvents] = useState<TimelineEvent[]>(() => getEvents());
+  const [eras, setEras] = useState<Era[]>([]);
+  const [events, setEvents] = useState<TimelineEvent[]>([]);
+  const [loading, setLoading] = useState(true);
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
+  const { addToast } = useToast();
+
+  useEffect(() => {
+    setEras(getEras());
+    setEvents(getEvents());
+    setLoading(false);
+  }, []);
 
   const [eraForm, setEraForm] = useState({
     id: '',
@@ -51,14 +62,19 @@ const TimelinePage: React.FC = () => {
       end: Number(eraForm.end),
       color: eraForm.color,
     };
-    if (eraForm.id) {
-      updateEra(era);
-      setEras(prev => prev.map(er => (er.id === era.id ? era : er)));
-    } else {
-      addEra(era);
-      setEras(prev => [...prev, era]);
+    try {
+      if (eraForm.id) {
+        updateEra(era);
+        setEras(prev => prev.map(er => (er.id === era.id ? era : er)));
+      } else {
+        addEra(era);
+        setEras(prev => [...prev, era]);
+      }
+      addToast({ type: 'success', message: 'Era salva.' });
+      setEraForm({ id: '', name: '', start: '', end: '', color: '#e0e0e0' });
+    } catch {
+      addToast({ type: 'error', message: 'Erro ao salvar era.' });
     }
-    setEraForm({ id: '', name: '', start: '', end: '', color: '#e0e0e0' });
   };
 
   const handleEventSubmit = (e: React.FormEvent) => {
@@ -70,14 +86,19 @@ const TimelinePage: React.FC = () => {
       eraId: eventForm.eraId || undefined,
       category: eventForm.category || undefined,
     };
-    if (eventForm.id) {
-      updateEvent(ev);
-      setEvents(prev => prev.map(eve => (eve.id === ev.id ? ev : eve)));
-    } else {
-      addEvent(ev);
-      setEvents(prev => [...prev, ev]);
+    try {
+      if (eventForm.id) {
+        updateEvent(ev);
+        setEvents(prev => prev.map(eve => (eve.id === ev.id ? ev : eve)));
+      } else {
+        addEvent(ev);
+        setEvents(prev => [...prev, ev]);
+      }
+      addToast({ type: 'success', message: 'Evento salvo.' });
+      setEventForm({ id: '', name: '', date: '', category: '', eraId: '' });
+    } catch {
+      addToast({ type: 'error', message: 'Erro ao salvar evento.' });
     }
-    setEventForm({ id: '', name: '', date: '', category: '', eraId: '' });
   };
 
   const handleEraEdit = (era: Era) => {
@@ -101,13 +122,23 @@ const TimelinePage: React.FC = () => {
   };
 
   const handleEraDelete = (id: string) => {
-    deleteEra(id);
-    setEras(prev => prev.filter(e => e.id !== id));
+    try {
+      deleteEra(id);
+      setEras(prev => prev.filter(e => e.id !== id));
+      addToast({ type: 'success', message: 'Era removida.' });
+    } catch {
+      addToast({ type: 'error', message: 'Erro ao remover era.' });
+    }
   };
 
   const handleEventDelete = (id: string) => {
-    deleteEvent(id);
-    setEvents(prev => prev.filter(e => e.id !== id));
+    try {
+      deleteEvent(id);
+      setEvents(prev => prev.filter(e => e.id !== id));
+      addToast({ type: 'success', message: 'Evento removido.' });
+    } catch {
+      addToast({ type: 'error', message: 'Erro ao remover evento.' });
+    }
   };
 
   const filteredEvents =
@@ -121,6 +152,7 @@ const TimelinePage: React.FC = () => {
 
       <form onSubmit={handleEraSubmit} className="space-x-2">
         <input
+          id="era-name"
           type="text"
           placeholder="Nome da era"
           value={eraForm.name}
@@ -154,16 +186,28 @@ const TimelinePage: React.FC = () => {
       </form>
 
       <div className="space-y-2">
-        {eras.map(era => (
-          <EraCard key={era.id} era={era} onEdit={handleEraEdit} onDelete={handleEraDelete} />
-        ))}
-        {eras.length === 0 && (
-          <p className="text-sm text-gray-600">Nenhuma era cadastrada.</p>
+        {loading ? (
+          <div className="space-y-2">
+            {[1, 2, 3].map(i => (
+              <Skeleton key={i} className="h-16" />
+            ))}
+          </div>
+        ) : eras.length === 0 ? (
+          <EmptyState
+            message="Nenhuma era cadastrada."
+            actionLabel="Adicionar Era"
+            onAction={() => document.getElementById('era-name')?.focus()}
+          />
+        ) : (
+          eras.map(era => (
+            <EraCard key={era.id} era={era} onEdit={handleEraEdit} onDelete={handleEraDelete} />
+          ))
         )}
       </div>
 
       <form onSubmit={handleEventSubmit} className="space-x-2">
         <input
+          id="event-name"
           type="text"
           placeholder="Nome do evento"
           value={eventForm.name}
@@ -209,11 +253,22 @@ const TimelinePage: React.FC = () => {
       />
 
       <div className="space-y-2">
-        {filteredEvents.map(ev => (
-          <EventCard key={ev.id} event={ev} onEdit={handleEventEdit} onDelete={handleEventDelete} />
-        ))}
-        {filteredEvents.length === 0 && (
-          <p className="text-sm text-gray-600">Nenhum evento encontrado.</p>
+        {loading ? (
+          <div className="space-y-2">
+            {[1, 2, 3].map(i => (
+              <Skeleton key={i} className="h-16" />
+            ))}
+          </div>
+        ) : filteredEvents.length === 0 ? (
+          <EmptyState
+            message="Nenhum evento encontrado."
+            actionLabel="Adicionar Evento"
+            onAction={() => document.getElementById('event-name')?.focus()}
+          />
+        ) : (
+          filteredEvents.map(ev => (
+            <EventCard key={ev.id} event={ev} onEdit={handleEventEdit} onDelete={handleEventDelete} />
+          ))
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- add toast provider and hooks for success/error messages
- show skeleton loaders and empty states across lists
- integrate toast notifications with character, quest, and timeline actions

## Testing
- `npm test` (fails: No test files found)
- `npm run lint` (fails: ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin")

------
https://chatgpt.com/codex/tasks/task_e_689c8eae44cc8325865ca350e6210b74