### PR TITLE
Enhance accessibility for Modal and Toolbar

### DIFF
--- a/src/app/core/ui/Modal.tsx
+++ b/src/app/core/ui/Modal.tsx
@@ -6,10 +6,81 @@ export interface ModalProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: string;
   asChild?: boolean;
   open?: boolean;
+  /** Callback acionado ao fechar o modal (Ex: pressionar Escape) */
+  onClose?: () => void;
 }
 
 export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
-  ({ className = '', variant, size, asChild = false, children, open = true, ...props }, ref) => {
+  (
+    {
+      className = '',
+      variant,
+      size,
+      asChild = false,
+      children,
+      open = true,
+      onClose,
+      ...props
+    },
+    ref,
+  ) => {
+    const innerRef = React.useRef<HTMLDivElement>(null);
+    React.useImperativeHandle(ref, () => innerRef.current as HTMLDivElement);
+
+    React.useEffect(() => {
+      if (!open || !innerRef.current) return;
+
+      const previouslyFocused = document.activeElement as HTMLElement | null;
+      const focusableSelectors = [
+        'a[href]',
+        'button:not([disabled])',
+        'textarea:not([disabled])',
+        'input:not([disabled])',
+        'select:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])',
+      ].join(',');
+
+      const trapFocus = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          e.stopPropagation();
+          onClose?.();
+          return;
+        }
+        if (e.key !== 'Tab') return;
+
+        const focusable = Array.from(
+          innerRef.current?.querySelectorAll<HTMLElement>(focusableSelectors) || [],
+        );
+        if (focusable.length === 0) {
+          e.preventDefault();
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        const active = document.activeElement as HTMLElement;
+        if (e.shiftKey) {
+          if (active === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else if (active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      };
+
+      const node = innerRef.current;
+      node.addEventListener('keydown', trapFocus);
+
+      const focusable = node.querySelectorAll<HTMLElement>(focusableSelectors);
+      (focusable[0] || node).focus();
+
+      return () => {
+        node.removeEventListener('keydown', trapFocus);
+        previouslyFocused?.focus();
+      };
+    }, [open, onClose]);
+
     if (!open) return null;
 
     const classes = [
@@ -23,17 +94,27 @@ export const Modal = React.forwardRef<HTMLDivElement, ModalProps>(
     if (asChild && React.isValidElement(children)) {
       return React.cloneElement(children as React.ReactElement, {
         className: classes,
-        ref,
+        ref: innerRef,
+        role: 'dialog',
+        'aria-modal': true,
+        tabIndex: -1,
         ...props,
       });
     }
 
     return (
-      <div ref={ref} className={classes} {...props}>
+      <div
+        ref={innerRef}
+        className={classes}
+        role="dialog"
+        aria-modal="true"
+        tabIndex={-1}
+        {...props}
+      >
         {children}
       </div>
     );
-  }
+  },
 );
 
 Modal.displayName = 'Modal';

--- a/src/app/core/ui/Toolbar.tsx
+++ b/src/app/core/ui/Toolbar.tsx
@@ -7,6 +7,85 @@ export interface ToolbarProps extends React.HTMLAttributes<HTMLDivElement> {
   asChild?: boolean;
 }
 
+export interface ToolbarButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Define se o botão é togglável */
+  togglable?: boolean;
+  /** Texto do tooltip exibido após um pequeno delay */
+  tooltip?: string;
+  /** Delay em milissegundos para exibir o tooltip */
+  tooltipDelay?: number;
+}
+
+export const ToolbarButton = React.forwardRef<HTMLButtonElement, ToolbarButtonProps>(
+  (
+    {
+      className = '',
+      togglable = false,
+      tooltip,
+      tooltipDelay = 500,
+      onClick,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const [pressed, setPressed] = React.useState(false);
+    const [showTooltip, setShowTooltip] = React.useState(false);
+    const timer = React.useRef<number>();
+
+    const activate = (e: React.SyntheticEvent<HTMLButtonElement>) => {
+      if (togglable) setPressed((p) => !p);
+      onClick?.(e as unknown as React.MouseEvent<HTMLButtonElement>);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLButtonElement>) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        activate(e);
+      }
+    };
+
+    const startTooltip = () => {
+      if (tooltip) {
+        timer.current = window.setTimeout(() => setShowTooltip(true), tooltipDelay);
+      }
+    };
+
+    const clearTooltip = () => {
+      if (timer.current) {
+        clearTimeout(timer.current);
+      }
+      setShowTooltip(false);
+    };
+
+    return (
+      <button
+        ref={ref}
+        type="button"
+        className={className}
+        aria-pressed={togglable ? pressed : undefined}
+        onClick={activate}
+        onKeyDown={handleKeyDown}
+        onMouseEnter={startTooltip}
+        onMouseLeave={clearTooltip}
+        onFocus={startTooltip}
+        onBlur={clearTooltip}
+        {...props}
+      >
+        {children}
+        {tooltip && showTooltip && (
+          <span role="tooltip" className="toolbar-tooltip">
+            {tooltip}
+          </span>
+        )}
+      </button>
+    );
+  },
+);
+
+ToolbarButton.displayName = 'ToolbarButton';
+
 export const Toolbar = React.forwardRef<HTMLDivElement, ToolbarProps>(
   ({ className = '', variant, size, asChild = false, children, ...props }, ref) => {
     const classes = [
@@ -21,16 +100,17 @@ export const Toolbar = React.forwardRef<HTMLDivElement, ToolbarProps>(
       return React.cloneElement(children as React.ReactElement, {
         className: classes,
         ref,
+        role: 'toolbar',
         ...props,
       });
     }
 
     return (
-      <div ref={ref} className={classes} {...props}>
+      <div ref={ref} className={classes} role="toolbar" {...props}>
         {children}
       </div>
     );
-  }
+  },
 );
 
 Toolbar.displayName = 'Toolbar';


### PR DESCRIPTION
## Summary
- add focus trapping, Escape close, and ARIA roles to Modal
- introduce accessible ToolbarButton with aria-pressed and delayed tooltips
- mark Toolbar container with toolbar role for keyboard navigation

## Testing
- `npm test` *(fails: No test files found, exiting with code 1)*
- `npm run lint` *(fails: ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin")*
- `npm run type-check` *(fails: Parameter 'event' implicitly has an 'any' type...)*

------
https://chatgpt.com/codex/tasks/task_e_689c981440308325ae52de9e18c85506