### PR TITLE
feat: add form ui kit and validation styles

### DIFF
--- a/src/app/core/ui/Form.tsx
+++ b/src/app/core/ui/Form.tsx
@@ -1,0 +1,67 @@
+// src/core/ui/Form.tsx
+import React from 'react';
+import Button from './Button';
+
+export interface FormRowProps extends React.HTMLAttributes<HTMLDivElement> {}
+export function FormRow({ className = '', ...props }: FormRowProps) {
+  const classes = ['flex flex-col gap-1', className].filter(Boolean).join(' ');
+  return <div className={classes} {...props} />;
+}
+
+export const Label = React.forwardRef<HTMLLabelElement, React.LabelHTMLAttributes<HTMLLabelElement>>(
+  ({ className = '', ...props }, ref) => {
+    const classes = ['text-sm font-medium', className].filter(Boolean).join(' ');
+    return <label ref={ref} className={classes} {...props} />;
+  }
+);
+Label.displayName = 'Label';
+
+export const HelpText = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className = '', ...props }, ref) => {
+    const classes = ['text-xs text-[color:var(--color-muted)]', className]
+      .filter(Boolean)
+      .join(' ');
+    return <p ref={ref} className={classes} {...props} />;
+  }
+);
+HelpText.displayName = 'HelpText';
+
+export const ErrorText = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className = '', ...props }, ref) => {
+    const classes = ['text-xs text-red-500 mt-1 hidden peer-invalid:block', className]
+      .filter(Boolean)
+      .join(' ');
+    return <p ref={ref} className={classes} {...props} />;
+  }
+);
+ErrorText.displayName = 'ErrorText';
+
+interface FormActionsProps extends React.HTMLAttributes<HTMLDivElement> {
+  onCancel?: () => void;
+  saveLabel?: string;
+  cancelLabel?: string;
+}
+
+export function FormActions({
+  className = '',
+  onCancel,
+  saveLabel = 'Salvar',
+  cancelLabel = 'Cancelar',
+  ...props
+}: FormActionsProps) {
+  const classes = [
+    'sticky bottom-0 flex justify-end gap-2 border-t mt-4 bg-[color:var(--color-panel)] p-4',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={classes} {...props}>
+      <Button type="submit">{saveLabel}</Button>
+      <Button type="button" variant="ghost" onClick={onCancel}>
+        {cancelLabel}
+      </Button>
+    </div>
+  );
+}

--- a/src/app/core/ui/Input.tsx
+++ b/src/app/core/ui/Input.tsx
@@ -11,6 +11,7 @@ export interface InputProps
 export const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className = '', variant, size, asChild = false, children, ...props }, ref) => {
     const classes = [
+      'border rounded px-3 py-2 peer invalid:border-red-500',
       className,
       variant ? `variant-${variant}` : '',
       size ? `size-${size}` : '',

--- a/src/app/core/ui/Select.tsx
+++ b/src/app/core/ui/Select.tsx
@@ -11,6 +11,7 @@ export interface SelectProps
 export const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
   ({ className = '', variant, size, asChild = false, children, ...props }, ref) => {
     const classes = [
+      'border rounded px-3 py-2 peer invalid:border-red-500',
       className,
       variant ? `variant-${variant}` : '',
       size ? `size-${size}` : '',

--- a/src/app/core/ui/Textarea.tsx
+++ b/src/app/core/ui/Textarea.tsx
@@ -10,6 +10,7 @@ export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextArea
 export const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className = '', variant, size, asChild = false, children, ...props }, ref) => {
     const classes = [
+      'border rounded px-3 py-2 peer invalid:border-red-500',
       className,
       variant ? `variant-${variant}` : '',
       size ? `size-${size}` : '',


### PR DESCRIPTION
## Summary
- add FormRow, Label, HelpText, ErrorText and sticky FormActions components
- apply default border and :invalid styles to Input, Select and Textarea

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin")*
- `npm run type-check` *(fails: type errors in existing modules)*

------
https://chatgpt.com/codex/tasks/task_e_689c991a5ccc83259d151837ff96d71f