### PR TITLE
feat: add focus mode and scene summary split

### DIFF
--- a/src/app/core/state/store.tsx
+++ b/src/app/core/state/store.tsx
@@ -4,6 +4,8 @@ import { create, StoreApi } from 'zustand';
 interface AppState {
   lastSaved: number | null;
   setLastSaved: (ts: number) => void;
+  focusMode: boolean;
+  setFocusMode: (focus: boolean) => void;
 }
 
 const AppStateContext = createContext<StoreApi<AppState> | null>(null);
@@ -14,6 +16,8 @@ export const AppStateProvider: React.FC<{ children: ReactNode }> = ({ children }
       create<AppState>((set) => ({
         lastSaved: null,
         setLastSaved: (ts) => set({ lastSaved: ts }),
+        focusMode: false,
+        setFocusMode: (focus) => set({ focusMode: focus }),
       })),
     [],
   );

--- a/src/app/core/ui/StatusBar.tsx
+++ b/src/app/core/ui/StatusBar.tsx
@@ -8,6 +8,7 @@ interface Props {
 const StatusBar: React.FC<Props> = ({ wordCount }) => {
   const lastSaved = useAppState((s) => s.lastSaved);
   const [text, setText] = useState('');
+  const readingTime = wordCount ? Math.ceil(wordCount / 200) : 0;
 
   useEffect(() => {
     const update = () => {
@@ -25,7 +26,9 @@ const StatusBar: React.FC<Props> = ({ wordCount }) => {
 
   return (
     <footer className="border-t px-4 py-1 text-sm flex justify-between bg-gray-50 dark:bg-gray-900">
-      <span>{wordCount != null ? `${wordCount} palavras` : ''}</span>
+      <span>
+        {wordCount != null ? `${wordCount} palavras · ${readingTime} min` : ''}
+      </span>
       <span>{text}</span>
     </footer>
   );

--- a/src/app/layout/MainLayout.tsx
+++ b/src/app/layout/MainLayout.tsx
@@ -1,19 +1,24 @@
 import React from 'react';
 import Sidebar from './Sidebar';
 import Topbar from './Topbar';
+import { useAppState } from '../core/state/store';
 
 interface Props {
   children: React.ReactNode;
 }
 
-const MainLayout: React.FC<Props> = ({ children }) => (
-  <div className="flex h-screen">
-    <Sidebar />
-    <div className="flex flex-col flex-1">
-      <Topbar />
-      <main className="flex-1 overflow-auto">{children}</main>
+const MainLayout: React.FC<Props> = ({ children }) => {
+  const focusMode = useAppState((s) => s.focusMode);
+
+  return (
+    <div className="flex h-screen">
+      {!focusMode && <Sidebar />}
+      <div className="flex flex-col flex-1">
+        {!focusMode && <Topbar />}
+        <main className="flex-1 overflow-auto">{children}</main>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default MainLayout;

--- a/src/modules/editor/components/WritingArea.tsx
+++ b/src/modules/editor/components/WritingArea.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 const modeClasses: Record<string, string> = {
   normal: 'bg-white text-gray-900',
-  focus: 'bg-amber-50 text-gray-800',
+  focus: 'bg-amber-50 text-gray-800 max-w-3xl mx-auto leading-relaxed',
   dark: 'bg-gray-900 text-gray-100',
 };
 

--- a/src/modules/editor/pages/EditorPage.tsx
+++ b/src/modules/editor/pages/EditorPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import ModeSwitcher from '../components/ModeSwitcher';
 import QuickTemplates from '../components/QuickTemplates';
 import RichToolbar from '../components/RichToolbar';
@@ -12,11 +12,14 @@ import { useAppState } from '../../../app/core/state/store';
 
 const EditorPage: React.FC = () => {
   const [content, setContent] = useState('');
+  const [summary, setSummary] = useState('');
+  const [showSummary, setShowSummary] = useState(false);
   const [mode, setMode] = useState<'normal' | 'focus' | 'dark'>('normal');
 
   useAutosave('editor-content', content);
 
   const setLastSaved = useAppState((s) => s.setLastSaved);
+  const setFocusMode = useAppState((s) => s.setFocusMode);
   useHotkeys({
     'ctrl+s': () => {
       localStorage.setItem('editor-content', content);
@@ -29,6 +32,10 @@ const EditorPage: React.FC = () => {
     return content.trim().split(/\s+/).filter(Boolean).length;
   }, [content]);
 
+  useEffect(() => {
+    setFocusMode(mode === 'focus');
+  }, [mode, setFocusMode]);
+
   const handleCommand = useCallback((cmd: string, value?: string) => {
     exec(cmd, value);
   }, []);
@@ -39,13 +46,35 @@ const EditorPage: React.FC = () => {
 
   return (
     <div className="flex flex-col h-full">
-      <div className="space-y-4 p-4 flex-1">
+      <div className="space-y-4 p-4 flex-1 flex flex-col">
         <div className="flex items-center gap-4">
           <ModeSwitcher mode={mode} onModeChange={setMode} />
+          <button
+            onClick={() => setShowSummary((s) => !s)}
+            className="px-2 py-1 border rounded"
+          >
+            {showSummary ? 'Ocultar sumário' : 'Mostrar sumário'}
+          </button>
         </div>
         <RichToolbar onCommand={handleCommand} />
         <QuickTemplates onInsert={handleInsertTemplate} />
-        <WritingArea value={content} onChange={setContent} mode={mode} />
+        {showSummary ? (
+          <div className="flex flex-1 gap-4">
+            <div className="flex-1">
+              <WritingArea value={content} onChange={setContent} mode={mode} />
+            </div>
+            <div className="border-l p-2 resize-x overflow-auto min-w-[16rem] max-w-[32rem]">
+              <textarea
+                value={summary}
+                onChange={(e) => setSummary(e.target.value)}
+                className="w-full h-full outline-none"
+                placeholder="Sumário de cenas..."
+              />
+            </div>
+          </div>
+        ) : (
+          <WritingArea value={content} onChange={setContent} mode={mode} />
+        )}
       </div>
       <StatusBar wordCount={wordCount} />
     </div>


### PR DESCRIPTION
## Summary
- hide navigation chrome during focus mode and widen writing area
- add optional resizable scene summary pane in editor
- show live word count and reading time in status bar

## Testing
- `npm test` *(fails: No test files found)*
- `npm run lint` *(fails: ESLint couldn't find the plugin "@typescript-eslint/eslint-plugin")*

------
https://chatgpt.com/codex/tasks/task_e_689c9d7e3fe083259b696a801a4e9512