### PR TITLE
feat: add demographic generation service

### DIFF
--- a/src/modules/world/index.ts
+++ b/src/modules/world/index.ts
@@ -2,3 +2,4 @@ export { default as LocationForm } from './components/LocationForm';
 export { default as LocationCard } from './components/LocationCard';
 export { default as AnalyticsPanel } from './components/AnalyticsPanel';
 export { default as WorldBuilderPage } from './pages/WorldBuilderPage';
+export * as Demography from './services/demography';

--- a/src/modules/world/services/demography.test.ts
+++ b/src/modules/world/services/demography.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { calcularDensidade } from './demography';
+
+describe('calcularDensidade', () => {
+  it('retorna categorias corretas', () => {
+    expect(calcularDensidade(1000, 0)).toBe('desolado');
+    expect(calcularDensidade(1000, 2)).toBe('baixo');
+    expect(calcularDensidade(1000, 7)).toBe('novo assentamento');
+    expect(calcularDensidade(1000, 12)).toBe('medio');
+    expect(calcularDensidade(1000, 17)).toBe('alto');
+    expect(calcularDensidade(1000, 25)).toBe('maximo');
+  });
+});

--- a/src/modules/world/services/demography.ts
+++ b/src/modules/world/services/demography.ts
@@ -1,0 +1,148 @@
+export type DensidadePopulacional =
+  | 'desolado'
+  | 'baixo'
+  | 'novo assentamento'
+  | 'medio'
+  | 'alto'
+  | 'maximo';
+
+export interface Assentamento {
+  nome: string;
+  populacao: number;
+  tamanho: string;
+  comercioProfissionais: string[];
+  recursos: string[];
+  nobres: string[];
+  sistemaPolitico: string;
+  leis: string[];
+  exercito: number;
+  religioes: string[];
+  seitas: string[];
+  guildas: string[];
+  guardas: number;
+}
+
+export interface Castelo {
+  nome: string;
+  dono: string;
+  funcional: boolean;
+}
+
+export interface Reino {
+  nome: string;
+  areaFisica: number; // em metros quadrados
+  tipoArea: string; // deserto, montanhoso, arquipelago, etc
+  populacao: number;
+  densidade: DensidadePopulacional;
+  assentamentos: Assentamento[];
+  castelos: Castelo[];
+  cidades: number;
+  nobres: string[];
+  sistemaPolitico: string;
+  leis: string[];
+  exercito: number;
+  religioes: string[];
+  seitas: string[];
+  guildas: string[];
+  guardas: number;
+}
+
+export const calcularDensidade = (
+  areaFisica: number,
+  populacao: number,
+): DensidadePopulacional => {
+  if (areaFisica <= 0 || populacao === 0) return 'desolado';
+  const densidade = populacao / (areaFisica / 1000); // pessoas por 1000 m2
+  if (densidade < 5) return 'baixo';
+  if (densidade < 10) return 'novo assentamento';
+  if (densidade < 15) return 'medio';
+  if (densidade < 20) return 'alto';
+  return 'maximo';
+};
+
+export const gerarAssentamento = (
+  overrides: Partial<Assentamento> = {},
+): Assentamento => {
+  const populacao = overrides.populacao ?? Math.floor(Math.random() * 5000);
+  return {
+    nome: overrides.nome ?? `Assentamento ${Math.floor(Math.random() * 1000)}`,
+    populacao,
+    tamanho:
+      overrides.tamanho ??
+      (populacao < 1000 ? 'pequeno' : populacao < 3000 ? 'medio' : 'grande'),
+    comercioProfissionais: overrides.comercioProfissionais ?? [],
+    recursos: overrides.recursos ?? [],
+    nobres: overrides.nobres ?? [],
+    sistemaPolitico: overrides.sistemaPolitico ?? 'feudal',
+    leis: overrides.leis ?? [],
+    exercito: overrides.exercito ?? 0,
+    religioes: overrides.religioes ?? [],
+    seitas: overrides.seitas ?? [],
+    guildas: overrides.guildas ?? [],
+    guardas: overrides.guardas ?? 0,
+  };
+};
+
+export const gerarReino = (
+  overrides: Partial<Reino> = {},
+): Reino => {
+  const areaFisica = overrides.areaFisica ?? (Math.floor(Math.random() * 5_000_000) + 1_000);
+  const populacao = overrides.populacao ?? Math.floor(Math.random() * 200_000);
+  return {
+    nome: overrides.nome ?? `Reino ${Math.floor(Math.random() * 1000)}`,
+    areaFisica,
+    tipoArea: overrides.tipoArea ?? 'planicie',
+    populacao,
+    densidade: calcularDensidade(areaFisica, populacao),
+    assentamentos: overrides.assentamentos ?? [],
+    castelos: overrides.castelos ?? [],
+    cidades: overrides.cidades ?? 0,
+    nobres: overrides.nobres ?? [],
+    sistemaPolitico: overrides.sistemaPolitico ?? 'monarquia',
+    leis: overrides.leis ?? [],
+    exercito: overrides.exercito ?? 0,
+    religioes: overrides.religioes ?? [],
+    seitas: overrides.seitas ?? [],
+    guildas: overrides.guildas ?? [],
+    guardas: overrides.guardas ?? 0,
+  };
+};
+
+const STORAGE_KEY = 'loreloom_demography_reinos';
+
+export const getReinos = (): Reino[] => {
+  if (typeof localStorage === 'undefined') return [];
+  const data = localStorage.getItem(STORAGE_KEY);
+  return data ? (JSON.parse(data) as Reino[]) : [];
+};
+
+const saveReinos = (reinos: Reino[]) => {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(reinos));
+};
+
+export const addReino = (reino: Reino) => {
+  const reinos = getReinos();
+  reinos.push(reino);
+  saveReinos(reinos);
+};
+
+export const updateReino = (reino: Reino) => {
+  const reinos = getReinos().map(r => (r.nome === reino.nome ? reino : r));
+  saveReinos(reinos);
+};
+
+export const deleteReino = (nome: string) => {
+  const reinos = getReinos().filter(r => r.nome !== nome);
+  saveReinos(reinos);
+};
+
+export default {
+  gerarAssentamento,
+  gerarReino,
+  calcularDensidade,
+  getReinos,
+  addReino,
+  updateReino,
+  deleteReino,
+};


### PR DESCRIPTION
## Summary
- add demographic generator and repository for kingdoms and settlements
- expose demography service from world module
- test density calculation

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: ESLint couldn't find plugin `@typescript-eslint/eslint-plugin`)*

------
https://chatgpt.com/codex/tasks/task_e_689cac209ab48325b2d45cc027dfca8c