### PR TITLE
Add repository unit tests

### DIFF
--- a/src/modules/book/services/bookRepository.test.ts
+++ b/src/modules/book/services/bookRepository.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { bookRepository } from './bookRepository';
+
+const createStorage = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  } as Storage;
+};
+
+beforeEach(() => {
+  // @ts-ignore - provide minimal localStorage implementation for Node env
+  global.localStorage = createStorage();
+});
+
+describe('bookRepository', () => {
+  it('adds and removes a book', () => {
+    const book = bookRepository.addBook('My Book');
+    expect(bookRepository.getProject().books).toHaveLength(1);
+    bookRepository.removeBook(book.id);
+    expect(bookRepository.getProject().books).toHaveLength(0);
+  });
+
+  it('handles chapters and scenes', () => {
+    const book = bookRepository.addBook('Book');
+    const chapter = bookRepository.addChapter(book.id, { title: 'Chap' });
+    bookRepository.addScene(book.id, chapter.id, { title: 'Scene' });
+
+    const project = bookRepository.getProject();
+    const savedBook = project.books[0];
+    expect(savedBook.chapters[0].title).toBe('Chap');
+    expect(savedBook.chapters[0].scenes[0].title).toBe('Scene');
+  });
+});

--- a/src/modules/characters/services/characterRepository.test.ts
+++ b/src/modules/characters/services/characterRepository.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getCharacters, addCharacter, updateCharacter, deleteCharacter } from './characterRepository';
+import type { Character } from '../types';
+
+const createStorage = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  } as Storage;
+};
+
+beforeEach(() => {
+  // @ts-ignore - minimal localStorage for Node env
+  global.localStorage = createStorage();
+});
+
+describe('characterRepository', () => {
+  it('adds, updates and deletes a character', () => {
+    const char: Character = { id: '1', name: 'John', role: 'hero', description: 'desc' };
+    addCharacter(char);
+    expect(getCharacters()).toHaveLength(1);
+
+    updateCharacter({ ...char, name: 'Jane' });
+    expect(getCharacters()[0].name).toBe('Jane');
+
+    deleteCharacter(char.id);
+    expect(getCharacters()).toHaveLength(0);
+  });
+});

--- a/src/modules/magic/services/magicRepository.test.ts
+++ b/src/modules/magic/services/magicRepository.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { magicRepository } from './magicRepository';
+
+const createStorage = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  } as Storage;
+};
+
+beforeEach(() => {
+  // @ts-ignore - minimal localStorage for Node env
+  global.localStorage = createStorage();
+});
+
+describe('magicRepository', () => {
+  it('updates rules and manages schools', () => {
+    magicRepository.updateRules('rule');
+    expect(magicRepository.getSystem().rules).toBe('rule');
+
+    const school = magicRepository.addSchool('Wizardry');
+    expect(magicRepository.getSystem().schools).toHaveLength(1);
+    magicRepository.removeSchool(school.id);
+    expect(magicRepository.getSystem().schools).toHaveLength(0);
+  });
+});

--- a/src/modules/plot/services/plotRepository.test.ts
+++ b/src/modules/plot/services/plotRepository.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { plotRepository } from './plotRepository';
+
+const createStorage = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  } as Storage;
+};
+
+beforeEach(() => {
+  // @ts-ignore - minimal localStorage for Node env
+  global.localStorage = createStorage();
+});
+
+describe('plotRepository', () => {
+  it('handles arcs and quests', () => {
+    const arc = plotRepository.addArc({
+      title: 'Arc',
+      description: '',
+      act1: '',
+      act2: '',
+      act3: '',
+      consequences: '',
+      progress: 0,
+      status: '',
+    });
+    const quest = plotRepository.addQuest(arc.id, {
+      title: 'Quest',
+      description: '',
+      type: '',
+      objectives: [],
+      obstacles: '',
+      twists: '',
+      rewards: '',
+      consequences: '',
+      progress: 0,
+      status: '',
+    });
+
+    let arcs = plotRepository.getArcs();
+    expect(arcs[0].quests[0].title).toBe('Quest');
+
+    plotRepository.removeQuest(arc.id, quest.id);
+    arcs = plotRepository.getArcs();
+    expect(arcs[0].quests).toHaveLength(0);
+
+    plotRepository.removeArc(arc.id);
+    expect(plotRepository.getArcs()).toHaveLength(0);
+  });
+});

--- a/src/modules/tech/services/techRepository.test.ts
+++ b/src/modules/tech/services/techRepository.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { techRepository } from './techRepository';
+
+const createStorage = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  } as Storage;
+};
+
+beforeEach(() => {
+  // @ts-ignore - minimal localStorage for Node env
+  global.localStorage = createStorage();
+});
+
+describe('techRepository', () => {
+  it('manages domains', () => {
+    const domain = techRepository.addDomain('AI');
+    expect(techRepository.getSystem().domains).toHaveLength(1);
+    techRepository.removeDomain(domain.id);
+    expect(techRepository.getSystem().domains).toHaveLength(0);
+  });
+
+  it('manages practitioners and devices', () => {
+    techRepository.addPractitioner('John', 'Engineer');
+    techRepository.addDevice({ name: 'Device', trl: 1, risks: '', requirements: '' });
+    const system = techRepository.getSystem();
+    expect(system.practitioners[0].name).toBe('John');
+    expect(system.devices[0].name).toBe('Device');
+  });
+});

--- a/src/modules/timeline/services/timelineRepository.test.ts
+++ b/src/modules/timeline/services/timelineRepository.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getEras,
+  addEra,
+  updateEra,
+  deleteEra,
+  getEvents,
+  addEvent,
+  updateEvent,
+  deleteEvent,
+} from './timelineRepository';
+
+const createStorage = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  } as Storage;
+};
+
+beforeEach(() => {
+  // @ts-ignore - minimal localStorage for Node env
+  global.localStorage = createStorage();
+});
+
+describe('timelineRepository', () => {
+  it('manages eras', () => {
+    const era = { id: 'e1', name: 'Ancient', start: 0, end: 100 };
+    addEra(era);
+    expect(getEras()).toHaveLength(1);
+    updateEra({ ...era, name: 'Medieval' });
+    expect(getEras()[0].name).toBe('Medieval');
+    deleteEra(era.id);
+    expect(getEras()).toHaveLength(0);
+  });
+
+  it('manages events', () => {
+    const event = { id: 'ev1', name: 'Battle', date: 50 };
+    addEvent(event);
+    expect(getEvents()).toHaveLength(1);
+    updateEvent({ ...event, name: 'Battle of Foo' });
+    expect(getEvents()[0].name).toBe('Battle of Foo');
+    deleteEvent(event.id);
+    expect(getEvents()).toHaveLength(0);
+  });
+});

--- a/src/modules/world/services/worldRepository.test.ts
+++ b/src/modules/world/services/worldRepository.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getLocations, addLocation, updateLocation, deleteLocation } from './worldRepository';
+
+const createStorage = () => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  } as Storage;
+};
+
+beforeEach(() => {
+  // @ts-ignore - minimal localStorage for Node env
+  global.localStorage = createStorage();
+});
+
+describe('worldRepository', () => {
+  it('adds, updates and deletes locations', () => {
+    const loc = {
+      id: 1,
+      name: 'City',
+      type: 'cidade',
+      climate: 'hot',
+      population: 1000,
+      professions: [],
+      economy: 'trade',
+      army: 10,
+      religions: [],
+      foods: [],
+      infrastructure: '',
+      strategicPoints: '',
+      history: '',
+    };
+    addLocation(loc as any);
+    expect(getLocations()).toHaveLength(1);
+
+    updateLocation({ ...loc, name: 'Town' } as any);
+    expect(getLocations()[0].name).toBe('Town');
+
+    deleteLocation(loc.id);
+    expect(getLocations()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for book repository covering nested chapter and scene handling
- exercise character, magic, plot, tech, timeline, and world repositories with basic CRUD operations

## Testing
- `npm test -- --run --environment node` *(fails: ReferenceError: document is not defined in existing UI tests)*

------
https://chatgpt.com/codex/tasks/task_e_689cbe74c1a48325857073f733891100