### PR TITLE
chore: resolve lint errors

### DIFF
--- a/script/initProject.js
+++ b/script/initProject.js
@@ -1,7 +1,7 @@
 // scripts/initProject.js
-const fs = require('fs');
-const path = require('path');
-const { execSync } = require('child_process');
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
 
 // Função para criar arquivo caso não exista
 function createFileIfNotExists(filePath, content) {

--- a/src/app/core/services/persistence/localStorageAdapter.ts
+++ b/src/app/core/services/persistence/localStorageAdapter.ts
@@ -26,8 +26,8 @@ const memoryStorage = (): StorageLike => {
 };
 
 const storage: StorageLike =
-  typeof globalThis !== 'undefined' && (globalThis as any).localStorage
-    ? (globalThis as any).localStorage
+  typeof window !== 'undefined' && window.localStorage
+    ? window.localStorage
     : memoryStorage();
 
 const localStorageAdapter: PersistenceAdapter = {

--- a/src/app/core/ui/Form.tsx
+++ b/src/app/core/ui/Form.tsx
@@ -1,8 +1,9 @@
 // src/core/ui/Form.tsx
+/* eslint-disable react/prop-types */
 import React from 'react';
 import Button from './Button';
 
-export interface FormRowProps extends React.HTMLAttributes<HTMLDivElement> {}
+export type FormRowProps = React.HTMLAttributes<HTMLDivElement>;
 export function FormRow({ className = '', ...props }: FormRowProps) {
   const classes = ['flex flex-col gap-1', className].filter(Boolean).join(' ');
   return <div className={classes} {...props} />;

--- a/src/modules/book/components/BookTree.tsx
+++ b/src/modules/book/components/BookTree.tsx
@@ -13,8 +13,12 @@ interface BookTreeProps {
   ) => void;
 }
 
+type DragPayload =
+  | { type: 'chapter'; bookId: string; chapterId: string }
+  | { type: 'scene'; bookId: string; chapterId: string; sceneId: string };
+
 const BookTree: React.FC<BookTreeProps> = ({ project, onSelectChapter, onSelectScene, onMoveChapter, onMoveScene }) => {
-  const handleDragStart = (e: React.DragEvent, payload: any) => {
+  const handleDragStart = (e: React.DragEvent, payload: DragPayload) => {
     e.dataTransfer.setData('application/json', JSON.stringify(payload));
   };
 

--- a/src/modules/book/components/ChapterMetaForm.tsx
+++ b/src/modules/book/components/ChapterMetaForm.tsx
@@ -9,7 +9,7 @@ interface ChapterMetaFormProps {
 const ChapterMetaForm: React.FC<ChapterMetaFormProps> = ({ chapter, onSave }) => {
   const [draft, setDraft] = useState<Chapter>(chapter);
 
-  const update = (field: keyof Chapter, value: any) => {
+  const update = <K extends keyof Chapter>(field: K, value: Chapter[K]) => {
     setDraft(prev => ({ ...prev, [field]: value }));
   };
 

--- a/src/modules/book/components/SceneMetaForm.tsx
+++ b/src/modules/book/components/SceneMetaForm.tsx
@@ -9,7 +9,7 @@ interface SceneMetaFormProps {
 const SceneMetaForm: React.FC<SceneMetaFormProps> = ({ scene, onSave }) => {
   const [draft, setDraft] = useState<Scene>(scene);
 
-  const update = (field: keyof Scene, value: any) => {
+  const update = <K extends keyof Scene>(field: K, value: Scene[K]) => {
     setDraft(prev => ({ ...prev, [field]: value }));
   };
 

--- a/src/modules/book/services/bookRepository.test.ts
+++ b/src/modules/book/services/bookRepository.test.ts
@@ -18,7 +18,7 @@ const createStorage = () => {
 };
 
 beforeEach(() => {
-  // @ts-ignore - provide minimal localStorage implementation for Node env
+  // @ts-expect-error - provide minimal localStorage implementation for Node env
   global.localStorage = createStorage();
 });
 

--- a/src/modules/book/services/bookRepository.ts
+++ b/src/modules/book/services/bookRepository.ts
@@ -61,7 +61,7 @@ export const bookRepository = {
   getProject: (): Project => loadProject(),
   saveProject,
   addBook: (title: string): Book => {
-    let newBook: Book = { id: uuidv4(), title, chapters: [] };
+    const newBook: Book = { id: uuidv4(), title, chapters: [] };
     modifyProject(project => {
       project.books.push(newBook);
     });
@@ -81,7 +81,7 @@ export const bookRepository = {
     });
   },
   addChapter: (bookId: string, data: Partial<Chapter>): Chapter => {
-    let newChapter: Chapter = {
+    const newChapter: Chapter = {
       id: uuidv4(),
       title: data.title || 'New Chapter',
       synopsis: data.synopsis || '',
@@ -117,7 +117,7 @@ export const bookRepository = {
     });
   },
   addScene: (bookId: string, chapterId: string, data: Partial<Scene>): Scene => {
-    let newScene: Scene = {
+    const newScene: Scene = {
       id: uuidv4(),
       title: data.title || 'New Scene',
       synopsis: data.synopsis || '',

--- a/src/modules/characters/services/characterRepository.test.ts
+++ b/src/modules/characters/services/characterRepository.test.ts
@@ -19,7 +19,7 @@ const createStorage = () => {
 };
 
 beforeEach(() => {
-  // @ts-ignore - minimal localStorage for Node env
+  // @ts-expect-error - minimal localStorage for Node env
   global.localStorage = createStorage();
 });
 

--- a/src/modules/magic/services/magicRepository.test.ts
+++ b/src/modules/magic/services/magicRepository.test.ts
@@ -18,7 +18,7 @@ const createStorage = () => {
 };
 
 beforeEach(() => {
-  // @ts-ignore - minimal localStorage for Node env
+  // @ts-expect-error - minimal localStorage for Node env
   global.localStorage = createStorage();
 });
 

--- a/src/modules/plot/components/ArcCard.tsx
+++ b/src/modules/plot/components/ArcCard.tsx
@@ -1,18 +1,6 @@
 import React from 'react';
 import styles from './ArcCard.module.css';
-
-type Arc = {
-  id: string;
-  title: string;
-  description: string;
-  act1: string;
-  act2: string;
-  act3: string;
-  consequences: string;
-  progress: number;
-  status: string;
-  quests: any[];
-};
+import type { Arc } from '../services/plotRepository';
 
 interface ArcCardProps {
   arc: Arc;

--- a/src/modules/plot/components/ArcForm.tsx
+++ b/src/modules/plot/components/ArcForm.tsx
@@ -1,19 +1,7 @@
 import React, { useState } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import styles from './ArcForm.module.css';
-
-type Arc = {
-  id: string;
-  title: string;
-  description: string;
-  act1: string;
-  act2: string;
-  act3: string;
-  consequences: string;
-  progress: number;
-  status: string;
-  quests: any[];
-};
+import type { Arc } from '../services/plotRepository';
 
 interface ArcFormProps {
   initialArc?: Arc;

--- a/src/modules/plot/services/plotRepository.test.ts
+++ b/src/modules/plot/services/plotRepository.test.ts
@@ -18,7 +18,7 @@ const createStorage = () => {
 };
 
 beforeEach(() => {
-  // @ts-ignore - minimal localStorage for Node env
+  // @ts-expect-error - minimal localStorage for Node env
   global.localStorage = createStorage();
 });
 

--- a/src/modules/relationships/RelationshipVisualizer.tsx
+++ b/src/modules/relationships/RelationshipVisualizer.tsx
@@ -1,15 +1,15 @@
 import React, { useEffect, useRef } from 'react';
 import * as d3 from 'd3';
 
-export interface RelationshipNode {
+export interface RelationshipNode extends d3.SimulationNodeDatum {
   id: string;
   name: string;
   group?: string;
 }
 
-export interface RelationshipLink {
-  source: string;
-  target: string;
+export interface RelationshipLink extends d3.SimulationLinkDatum<RelationshipNode> {
+  source: string | RelationshipNode;
+  target: string | RelationshipNode;
   value?: number;
 }
 
@@ -81,16 +81,21 @@ export const RelationshipVisualizer: React.FC<RelationshipVisualizerProps> = ({ 
 
     node.append('title').text(d => d.name);
 
+    const getX = (n: string | RelationshipNode) =>
+      typeof n === 'object' && n.x !== undefined ? n.x : 0;
+    const getY = (n: string | RelationshipNode) =>
+      typeof n === 'object' && n.y !== undefined ? n.y : 0;
+
     simulation.on('tick', () => {
       link
-        .attr('x1', d => (d.source as any).x)
-        .attr('y1', d => (d.source as any).y)
-        .attr('x2', d => (d.target as any).x)
-        .attr('y2', d => (d.target as any).y);
+        .attr('x1', d => getX(d.source))
+        .attr('y1', d => getY(d.source))
+        .attr('x2', d => getX(d.target))
+        .attr('y2', d => getY(d.target));
 
       node
-        .attr('cx', d => (d as any).x)
-        .attr('cy', d => (d as any).y);
+        .attr('cx', d => d.x ?? 0)
+        .attr('cy', d => d.y ?? 0);
     });
   }, [data, width, height]);
 

--- a/src/modules/tech/components/DeviceList.tsx
+++ b/src/modules/tech/components/DeviceList.tsx
@@ -17,7 +17,7 @@ const DeviceList: React.FC<DeviceListProps> = ({ devices, onAdd, onUpdate, onRem
     requirements: '',
   });
 
-  const updateForm = (field: keyof Omit<Device, 'id'>, value: any) => {
+  const updateForm = <K extends keyof Omit<Device, 'id'>>(field: K, value: Omit<Device, 'id'>[K]) => {
     setForm(prev => ({ ...prev, [field]: value }));
   };
 

--- a/src/modules/tech/services/techRepository.test.ts
+++ b/src/modules/tech/services/techRepository.test.ts
@@ -18,7 +18,7 @@ const createStorage = () => {
 };
 
 beforeEach(() => {
-  // @ts-ignore - minimal localStorage for Node env
+  // @ts-expect-error - minimal localStorage for Node env
   global.localStorage = createStorage();
 });
 

--- a/src/modules/timeline/TimelineWorldHistoryManager.tsx
+++ b/src/modules/timeline/TimelineWorldHistoryManager.tsx
@@ -49,7 +49,6 @@ export const TimelineWorldHistoryManager: React.FC<TimelineProps> = ({ eras, eve
   useEffect(() => {
     const svg = d3.select(svgRef.current);
     const width = +svg.attr('width');
-    const height = +svg.attr('height');
     svg.selectAll('*').remove();
 
     if (events.length === 0) return;
@@ -78,8 +77,9 @@ export const TimelineWorldHistoryManager: React.FC<TimelineProps> = ({ eras, eve
 
     // Draw events as circles
     const eventGroup = svg.append('g').attr('class', 'events');
-    const eventSelection = eventGroup.selectAll('circle')
-      .data(filteredEvents, (d: any) => d.id);
+    const eventSelection = eventGroup
+      .selectAll<SVGCircleElement, TimelineEvent>('circle')
+      .data(filteredEvents, d => d.id);
 
     const entered = eventSelection.enter();
 

--- a/src/modules/timeline/services/timelineRepository.test.ts
+++ b/src/modules/timeline/services/timelineRepository.test.ts
@@ -27,7 +27,7 @@ const createStorage = () => {
 };
 
 beforeEach(() => {
-  // @ts-ignore - minimal localStorage for Node env
+  // @ts-expect-error - minimal localStorage for Node env
   global.localStorage = createStorage();
 });
 

--- a/src/modules/world/services/worldRepository.test.ts
+++ b/src/modules/world/services/worldRepository.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { getLocations, addLocation, updateLocation, deleteLocation } from './worldRepository';
+import type { Location } from '../components/LocationForm';
 
 const createStorage = () => {
   let store: Record<string, string> = {};
@@ -18,13 +19,13 @@ const createStorage = () => {
 };
 
 beforeEach(() => {
-  // @ts-ignore - minimal localStorage for Node env
+  // @ts-expect-error - minimal localStorage for Node env
   global.localStorage = createStorage();
 });
 
 describe('worldRepository', () => {
   it('adds, updates and deletes locations', () => {
-    const loc = {
+    const loc: Location = {
       id: 1,
       name: 'City',
       type: 'cidade',
@@ -39,10 +40,10 @@ describe('worldRepository', () => {
       strategicPoints: '',
       history: '',
     };
-    addLocation(loc as any);
+    addLocation(loc);
     expect(getLocations()).toHaveLength(1);
 
-    updateLocation({ ...loc, name: 'Town' } as any);
+    updateLocation({ ...loc, name: 'Town' });
     expect(getLocations()[0].name).toBe('Town');
 
     deleteLocation(loc.id);


### PR DESCRIPTION
## Summary
- use ESM imports in init script and remove `any` from storage adapter
- tighten types across UI components and services
- replace `@ts-ignore` usages with `@ts-expect-error`

## Testing
- `npm run lint` *(fails: @typescript-eslint/eslint-plugin missing)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689ccf373458832585843c8efc620c99