### PR TITLE
feat: add JSON persistence layer

### DIFF
--- a/data.json
+++ b/data.json
@@ -1,0 +1,15 @@
+{
+  "title": "Projeto LoreLoom",
+  "content": "",
+  "characters": [],
+  "locations": [],
+  "items": [],
+  "languages": [],
+  "timeline": [],
+  "notes": [],
+  "economy": {
+    "currencies": [],
+    "resources": [],
+    "markets": []
+  }
+}

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,4 +1,4 @@
-// Dados do projeto (simulação de armazenamento local)
+// Dados do projeto carregados do servidor
     let projectData = {
       title: "Projeto LoreLoom",
       content: "",
@@ -14,6 +14,14 @@
         markets: []
       }
     };
+
+    async function loadProject() {
+      const res = await fetch('/load');
+      projectData = await res.json();
+      document.getElementById('mainText').value = projectData.content || '';
+      document.getElementById('documentTitle').value = projectData.title || '';
+      updateWordCount();
+    }
 
     // Navegação entre painéis
     document.querySelectorAll('.nav-item').forEach(item => {
@@ -140,15 +148,19 @@
     document.getElementById('mainText').addEventListener('input', updateWordCount);
 
     // Funções de salvamento (placeholder)
-    function saveProject() {
+    async function saveProject() {
       projectData.content = document.getElementById('mainText').value;
       projectData.title = document.getElementById('documentTitle').value;
-      
+      await fetch('/save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(projectData)
+      });
       document.getElementById('saveStatus').textContent = 'Salvo ' + new Date().toLocaleTimeString();
       console.log('Projeto salvo:', projectData);
     }
 
-    function saveCharacter() {
+    async function saveCharacter() {
       const character = {
         id: Date.now(),
         name: document.getElementById('charName').value,
@@ -165,6 +177,11 @@
       };
       
       projectData.characters.push(character);
+      await fetch('/characters', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(character)
+      });
       closeModal('characterModal');
       console.log('Personagem salvo:', character);
     }
@@ -280,4 +297,4 @@
     });
 
     // Inicialização
-    updateWordCount();
+    loadProject();

--- a/server.js
+++ b/server.js
@@ -1,11 +1,57 @@
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
 
 const app = express();
 const port = process.env.PORT || 3000;
+const DATA_FILE = path.join(__dirname, 'data.json');
 
+app.use(express.json());
 // Serve static assets from the repository root
 app.use(express.static(__dirname));
+
+function readData() {
+  try {
+    return JSON.parse(fs.readFileSync(DATA_FILE, 'utf8'));
+  } catch {
+    return {
+      title: 'Projeto LoreLoom',
+      content: '',
+      characters: [],
+      locations: [],
+      items: [],
+      languages: [],
+      timeline: [],
+      notes: [],
+      economy: { currencies: [], resources: [], markets: [] }
+    };
+  }
+}
+
+function writeData(data) {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(data, null, 2));
+}
+
+app.post('/save', (req, res) => {
+  writeData(req.body);
+  res.json({ status: 'ok' });
+});
+
+app.get('/load', (_req, res) => {
+  res.json(readData());
+});
+
+app.get('/characters', (_req, res) => {
+  const data = readData();
+  res.json(data.characters || []);
+});
+
+app.post('/characters', (req, res) => {
+  const data = readData();
+  data.characters.push(req.body);
+  writeData(data);
+  res.json({ status: 'ok' });
+});
 
 // Fallback to the main HTML file
 app.get('/', (_req, res) => {


### PR DESCRIPTION
## Summary
- add backend API to persist project data to disk
- load and save project data via fetch from frontend
- store default project structure in data.json

## Testing
- `npm test`
- `npm start` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68a76c89ff608325b40444be60c1a033