### PR TITLE
Implement full CRUD for entities

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -15,12 +15,163 @@
       }
     };
 
+    // IDs dos itens em edição para cada entidade
+    const editingIds = {
+      character: null,
+      location: null,
+      item: null,
+      language: null,
+      event: null,
+      note: null
+    };
+
+    // Renderização das listas na interface
+    function renderCharacterList() {
+      const list = document.getElementById('characterList');
+      if (!list) return;
+      list.innerHTML = '';
+      projectData.characters.forEach(c => {
+        const tags = (c.tags || []).map(t => `<div class="tag">${t}</div>`).join('');
+        const item = document.createElement('div');
+        item.className = 'list-item';
+        item.innerHTML = `
+          <div>
+            <strong>${c.name}</strong>
+            <div style="font-size: 0.9em; color: #64748b;">${[c.role, c.race].filter(Boolean).join(', ')}</div>
+            ${tags}
+          </div>
+          <div>
+            <button class="btn" onclick="editCharacter(${c.id})">Editar</button>
+            <button class="btn btn-danger" onclick="deleteCharacter(${c.id})">Excluir</button>
+          </div>
+        `;
+        list.appendChild(item);
+      });
+    }
+
+    function renderLocationList() {
+      const list = document.getElementById('locationList');
+      if (!list) return;
+      list.innerHTML = '';
+      projectData.locations.forEach(l => {
+        const tags = (l.tags || []).map(t => `<div class="tag">${t}</div>`).join('');
+        const item = document.createElement('div');
+        item.className = 'list-item';
+        item.innerHTML = `
+          <div>
+            <strong>${l.name}</strong>
+            <div style="font-size: 0.9em; color: #64748b;">${[l.type, l.region].filter(Boolean).join(' • ')}</div>
+            ${tags}
+          </div>
+          <div>
+            <button class="btn" onclick="editLocation(${l.id})">Editar</button>
+            <button class="btn btn-danger" onclick="deleteLocation(${l.id})">Excluir</button>
+          </div>
+        `;
+        list.appendChild(item);
+      });
+    }
+
+    function renderItemList() {
+      const list = document.getElementById('itemList');
+      if (!list) return;
+      list.innerHTML = '';
+      projectData.items.forEach(i => {
+        const item = document.createElement('div');
+        item.className = 'list-item';
+        item.innerHTML = `
+          <div>
+            <strong>${i.name}</strong>
+            <div style="font-size: 0.9em; color: #64748b;">${[i.type, i.rarity].filter(Boolean).join(' • ')}</div>
+          </div>
+          <div>
+            <button class="btn" onclick="editItem(${i.id})">Editar</button>
+            <button class="btn btn-danger" onclick="deleteItem(${i.id})">Excluir</button>
+          </div>
+        `;
+        list.appendChild(item);
+      });
+    }
+
+    function renderLanguageList() {
+      const list = document.getElementById('languageList');
+      if (!list) return;
+      list.innerHTML = '';
+      projectData.languages.forEach(l => {
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.innerHTML = `
+          <h3>${l.name}</h3>
+          <div style="font-size: 0.9em; color: #64748b;">${l.family || ''}</div>
+          <div style="margin-top:8px;">
+            <button class="btn" onclick="editLanguage(${l.id})">Editar</button>
+            <button class="btn btn-danger" onclick="deleteLanguage(${l.id})">Excluir</button>
+          </div>
+        `;
+        list.appendChild(card);
+      });
+    }
+
+    function renderEventList() {
+      const list = document.getElementById('eventList');
+      if (!list) return;
+      list.innerHTML = '';
+      projectData.timeline.forEach(e => {
+        const card = document.createElement('div');
+        card.className = 'card';
+        card.style.marginBottom = '12px';
+        card.style.position = 'relative';
+        card.innerHTML = `
+          <div style="position: absolute; left: -26px; top: 16px; width: 12px; height: 12px; background: #3b82f6; border-radius: 50%;"></div>
+          <strong>${e.date}</strong> - ${e.name}
+          <div style="font-size: 0.9em; color: #64748b; margin-top: 4px;">${e.description || ''}</div>
+          ${(e.importance ? `<div class="tag">${e.importance}</div>` : '')}
+          <div style="margin-top: 8px;">
+            <button class="btn" onclick="editEvent(${e.id})">Editar</button>
+            <button class="btn btn-danger" onclick="deleteEvent(${e.id})">Excluir</button>
+          </div>
+        `;
+        list.appendChild(card);
+      });
+    }
+
+    function renderNoteList() {
+      const list = document.getElementById('noteList');
+      if (!list) return;
+      list.innerHTML = '';
+      projectData.notes.forEach(n => {
+        const tags = (n.tags || []).map(t => `<div class="tag">${t}</div>`).join('');
+        const card = document.createElement('div');
+        card.className = 'card';
+        const date = n.createdAt ? new Date(n.createdAt).toLocaleDateString() : '';
+        card.innerHTML = `
+          <div class="card-header">
+            <strong>${n.title}</strong>
+            <span style="font-size: 0.8em; color: #64748b;">${date}</span>
+          </div>
+          <p style="font-size: 0.9em; margin: 8px 0;">${n.content}</p>
+          ${tags}
+          <div style="margin-top: 12px;">
+            <button class="btn" onclick="editNote(${n.id})">Editar</button>
+            <button class="btn btn-danger" onclick="deleteNote(${n.id})">Excluir</button>
+          </div>
+        `;
+        list.appendChild(card);
+      });
+    }
+
     async function loadProject() {
       const res = await fetch('/load');
       projectData = await res.json();
       document.getElementById('mainText').value = projectData.content || '';
       document.getElementById('documentTitle').value = projectData.title || '';
       updateWordCount();
+      renderCharacterList();
+      renderLocationList();
+      renderItemList();
+      renderLanguageList();
+      renderEventList();
+      renderNoteList();
     }
 
     // Navegação entre painéis
@@ -54,26 +205,38 @@
 
     // Funções para abrir modais
     function openCharacterModal() {
+      editingIds.character = null;
+      ['charName','charAge','charRace','charClass','charRole','charAppearance','charPersonality','charBackground','charSkills','charRelationships','charTags'].forEach(id => document.getElementById(id).value = '');
       document.getElementById('characterModal').classList.add('active');
     }
 
     function openLocationModal() {
+      editingIds.location = null;
+      ['locName','locType','locRegion','locPopulation','locDescription','locRuler','locInterests','locHistory','locTags'].forEach(id => document.getElementById(id).value = '');
       document.getElementById('locationModal').classList.add('active');
     }
 
     function openItemModal() {
+      editingIds.item = null;
+      ['itemName','itemType','itemRarity','itemDescription','itemProperties','itemValue','itemWeight','itemHistory','itemLocation'].forEach(id => document.getElementById(id).value = '');
       document.getElementById('itemModal').classList.add('active');
     }
 
     function openLanguageModal() {
+      editingIds.language = null;
+      ['langName','langFamily','langScript','langSpeakers','langPhonetics','langGrammar','langExamples'].forEach(id => document.getElementById(id).value = '');
       document.getElementById('languageModal').classList.add('active');
     }
 
     function openEventModal() {
+      editingIds.event = null;
+      ['eventName','eventDate','eventType','eventLocation','eventDescription','eventCharacters','eventConsequences','eventImportance'].forEach(id => document.getElementById(id).value = '');
       document.getElementById('eventModal').classList.add('active');
     }
 
     function openNoteModal() {
+      editingIds.note = null;
+      ['noteTitle','noteCategory','noteContent','noteTags'].forEach(id => document.getElementById(id).value = '');
       document.getElementById('noteModal').classList.add('active');
     }
 
@@ -162,7 +325,7 @@
 
     async function saveCharacter() {
       const character = {
-        id: Date.now(),
+        id: editingIds.character || Date.now(),
         name: document.getElementById('charName').value,
         age: document.getElementById('charAge').value,
         race: document.getElementById('charRace').value,
@@ -175,20 +338,23 @@
         relationships: document.getElementById('charRelationships').value,
         tags: document.getElementById('charTags').value.split(',').map(t => t.trim())
       };
-      
-      projectData.characters.push(character);
-      await fetch('/characters', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(character)
-      });
+
+      if (editingIds.character) {
+        const idx = projectData.characters.findIndex(c => c.id === editingIds.character);
+        if (idx !== -1) projectData.characters[idx] = character;
+      } else {
+        projectData.characters.push(character);
+      }
+
+      await saveProject();
+      renderCharacterList();
       closeModal('characterModal');
       console.log('Personagem salvo:', character);
     }
 
-    function saveLocation() {
+    async function saveLocation() {
       const location = {
-        id: Date.now(),
+        id: editingIds.location || Date.now(),
         name: document.getElementById('locName').value,
         type: document.getElementById('locType').value,
         region: document.getElementById('locRegion').value,
@@ -199,15 +365,23 @@
         history: document.getElementById('locHistory').value,
         tags: document.getElementById('locTags').value.split(',').map(t => t.trim())
       };
-      
-      projectData.locations.push(location);
+
+      if (editingIds.location) {
+        const idx = projectData.locations.findIndex(l => l.id === editingIds.location);
+        if (idx !== -1) projectData.locations[idx] = location;
+      } else {
+        projectData.locations.push(location);
+      }
+
+      await saveProject();
+      renderLocationList();
       closeModal('locationModal');
       console.log('Local salvo:', location);
     }
 
-    function saveItem() {
+    async function saveItem() {
       const item = {
-        id: Date.now(),
+        id: editingIds.item || Date.now(),
         name: document.getElementById('itemName').value,
         type: document.getElementById('itemType').value,
         rarity: document.getElementById('itemRarity').value,
@@ -218,15 +392,23 @@
         history: document.getElementById('itemHistory').value,
         location: document.getElementById('itemLocation').value
       };
-      
-      projectData.items.push(item);
+
+      if (editingIds.item) {
+        const idx = projectData.items.findIndex(i => i.id === editingIds.item);
+        if (idx !== -1) projectData.items[idx] = item;
+      } else {
+        projectData.items.push(item);
+      }
+
+      await saveProject();
+      renderItemList();
       closeModal('itemModal');
       console.log('Item salvo:', item);
     }
 
-    function saveLanguage() {
+    async function saveLanguage() {
       const language = {
-        id: Date.now(),
+        id: editingIds.language || Date.now(),
         name: document.getElementById('langName').value,
         family: document.getElementById('langFamily').value,
         script: document.getElementById('langScript').value,
@@ -235,15 +417,23 @@
         grammar: document.getElementById('langGrammar').value,
         examples: document.getElementById('langExamples').value
       };
-      
-      projectData.languages.push(language);
+
+      if (editingIds.language) {
+        const idx = projectData.languages.findIndex(l => l.id === editingIds.language);
+        if (idx !== -1) projectData.languages[idx] = language;
+      } else {
+        projectData.languages.push(language);
+      }
+
+      await saveProject();
+      renderLanguageList();
       closeModal('languageModal');
       console.log('Língua salva:', language);
     }
 
-    function saveEvent() {
+    async function saveEvent() {
       const event = {
-        id: Date.now(),
+        id: editingIds.event || Date.now(),
         name: document.getElementById('eventName').value,
         date: document.getElementById('eventDate').value,
         type: document.getElementById('eventType').value,
@@ -253,25 +443,168 @@
         consequences: document.getElementById('eventConsequences').value,
         importance: document.getElementById('eventImportance').value
       };
-      
-      projectData.timeline.push(event);
+
+      if (editingIds.event) {
+        const idx = projectData.timeline.findIndex(e => e.id === editingIds.event);
+        if (idx !== -1) projectData.timeline[idx] = event;
+      } else {
+        projectData.timeline.push(event);
+      }
+
+      await saveProject();
+      renderEventList();
       closeModal('eventModal');
       console.log('Evento salvo:', event);
     }
 
-    function saveNote() {
+    async function saveNote() {
       const note = {
-        id: Date.now(),
+        id: editingIds.note || Date.now(),
         title: document.getElementById('noteTitle').value,
         category: document.getElementById('noteCategory').value,
         content: document.getElementById('noteContent').value,
         tags: document.getElementById('noteTags').value.split(',').map(t => t.trim()),
-        createdAt: new Date()
+        createdAt: editingIds.note ? projectData.notes.find(n => n.id === editingIds.note)?.createdAt || new Date() : new Date()
       };
-      
-      projectData.notes.push(note);
+
+      if (editingIds.note) {
+        const idx = projectData.notes.findIndex(n => n.id === editingIds.note);
+        if (idx !== -1) projectData.notes[idx] = note;
+      } else {
+        projectData.notes.push(note);
+      }
+
+      await saveProject();
+      renderNoteList();
       closeModal('noteModal');
       console.log('Nota salva:', note);
+    }
+
+    // Funções de edição e exclusão
+    function editCharacter(id) {
+      const c = projectData.characters.find(ch => ch.id === id);
+      if (!c) return;
+      editingIds.character = id;
+      document.getElementById('charName').value = c.name || '';
+      document.getElementById('charAge').value = c.age || '';
+      document.getElementById('charRace').value = c.race || '';
+      document.getElementById('charClass').value = c.class || '';
+      document.getElementById('charRole').value = c.role || '';
+      document.getElementById('charAppearance').value = c.appearance || '';
+      document.getElementById('charPersonality').value = c.personality || '';
+      document.getElementById('charBackground').value = c.background || '';
+      document.getElementById('charSkills').value = c.skills || '';
+      document.getElementById('charRelationships').value = c.relationships || '';
+      document.getElementById('charTags').value = (c.tags || []).join(', ');
+      document.getElementById('characterModal').classList.add('active');
+    }
+
+    async function deleteCharacter(id) {
+      projectData.characters = projectData.characters.filter(c => c.id !== id);
+      await saveProject();
+      renderCharacterList();
+    }
+
+    function editLocation(id) {
+      const l = projectData.locations.find(loc => loc.id === id);
+      if (!l) return;
+      editingIds.location = id;
+      document.getElementById('locName').value = l.name || '';
+      document.getElementById('locType').value = l.type || '';
+      document.getElementById('locRegion').value = l.region || '';
+      document.getElementById('locPopulation').value = l.population || '';
+      document.getElementById('locDescription').value = l.description || '';
+      document.getElementById('locRuler').value = l.ruler || '';
+      document.getElementById('locInterests').value = l.interests || '';
+      document.getElementById('locHistory').value = l.history || '';
+      document.getElementById('locTags').value = (l.tags || []).join(', ');
+      document.getElementById('locationModal').classList.add('active');
+    }
+
+    async function deleteLocation(id) {
+      projectData.locations = projectData.locations.filter(l => l.id !== id);
+      await saveProject();
+      renderLocationList();
+    }
+
+    function editItem(id) {
+      const i = projectData.items.find(it => it.id === id);
+      if (!i) return;
+      editingIds.item = id;
+      document.getElementById('itemName').value = i.name || '';
+      document.getElementById('itemType').value = i.type || '';
+      document.getElementById('itemRarity').value = i.rarity || '';
+      document.getElementById('itemDescription').value = i.description || '';
+      document.getElementById('itemProperties').value = i.properties || '';
+      document.getElementById('itemValue').value = i.value || '';
+      document.getElementById('itemWeight').value = i.weight || '';
+      document.getElementById('itemHistory').value = i.history || '';
+      document.getElementById('itemLocation').value = i.location || '';
+      document.getElementById('itemModal').classList.add('active');
+    }
+
+    async function deleteItem(id) {
+      projectData.items = projectData.items.filter(i => i.id !== id);
+      await saveProject();
+      renderItemList();
+    }
+
+    function editLanguage(id) {
+      const l = projectData.languages.find(lang => lang.id === id);
+      if (!l) return;
+      editingIds.language = id;
+      document.getElementById('langName').value = l.name || '';
+      document.getElementById('langFamily').value = l.family || '';
+      document.getElementById('langScript').value = l.script || '';
+      document.getElementById('langSpeakers').value = l.speakers || '';
+      document.getElementById('langPhonetics').value = l.phonetics || '';
+      document.getElementById('langGrammar').value = l.grammar || '';
+      document.getElementById('langExamples').value = l.examples || '';
+      document.getElementById('languageModal').classList.add('active');
+    }
+
+    async function deleteLanguage(id) {
+      projectData.languages = projectData.languages.filter(l => l.id !== id);
+      await saveProject();
+      renderLanguageList();
+    }
+
+    function editEvent(id) {
+      const e = projectData.timeline.find(ev => ev.id === id);
+      if (!e) return;
+      editingIds.event = id;
+      document.getElementById('eventName').value = e.name || '';
+      document.getElementById('eventDate').value = e.date || '';
+      document.getElementById('eventType').value = e.type || '';
+      document.getElementById('eventLocation').value = e.location || '';
+      document.getElementById('eventDescription').value = e.description || '';
+      document.getElementById('eventCharacters').value = (e.characters || []).join(', ');
+      document.getElementById('eventConsequences').value = e.consequences || '';
+      document.getElementById('eventImportance').value = e.importance || '';
+      document.getElementById('eventModal').classList.add('active');
+    }
+
+    async function deleteEvent(id) {
+      projectData.timeline = projectData.timeline.filter(e => e.id !== id);
+      await saveProject();
+      renderEventList();
+    }
+
+    function editNote(id) {
+      const n = projectData.notes.find(nt => nt.id === id);
+      if (!n) return;
+      editingIds.note = id;
+      document.getElementById('noteTitle').value = n.title || '';
+      document.getElementById('noteCategory').value = n.category || '';
+      document.getElementById('noteContent').value = n.content || '';
+      document.getElementById('noteTags').value = (n.tags || []).join(', ');
+      document.getElementById('noteModal').classList.add('active');
+    }
+
+    async function deleteNote(id) {
+      projectData.notes = projectData.notes.filter(n => n.id !== id);
+      await saveProject();
+      renderNoteList();
     }
 
     function checkConsistency() {

--- a/loreloom.html
+++ b/loreloom.html
@@ -127,7 +127,7 @@
               <button class="btn btn-primario" onclick="openLocationModal()">Novo Local</button>
             </div>
             
-            <div class="location-list">
+            <div class="location-list" id="locationList">
               <div class="list-item">
                 <div>
                   <strong>Gondor</strong>
@@ -193,7 +193,7 @@
               </div>
             </div>
             
-            <div class="item-list">
+            <div class="item-list" id="itemList">
               <div class="list-item">
                 <div>
                   <strong>Andúril</strong>
@@ -218,9 +218,9 @@
             <h2>Sistema Econômico</h2>
           </div>
           
-          <div class="grid grid-2">
-            <div>
-              <h3>Moedas</h3>
+            <div class="grid grid-2">
+              <div>
+                <h3>Moedas</h3>
               <div class="form-group">
                 <label>Nome da Moeda</label>
                 <input type="text" class="form-control" placeholder="ex: Moedas de Ouro">
@@ -294,7 +294,7 @@
             <button class="btn btn-primario" onclick="openLanguageModal()">Nova Língua</button>
           </div>
           
-          <div class="grid grid-2">
+          <div class="grid grid-2" id="languageList">
             <div class="card">
               <h3>Élfico (Sindarin)</h3>
               <div class="form-group">
@@ -383,7 +383,7 @@
             </select>
           </div>
           
-          <div style="border-left: 3px solid #3b82f6; padding-left: 20px;">
+          <div style="border-left: 3px solid #3b82f6; padding-left: 20px;" id="eventList">
             <div class="card" style="margin-bottom: 12px; position: relative;">
               <div style="position: absolute; left: -26px; top: 16px; width: 12px; height: 12px; background: #3b82f6; border-radius: 50%;"></div>
               <strong>T.A. 3018</strong> - Início da Jornada do Anel
@@ -450,7 +450,7 @@
             </div>
           </div>
           
-          <div class="grid grid-2">
+          <div class="grid grid-2" id="noteList">
             <div class="card">
               <div class="card-header">
                 <strong>Sistema de Magia</strong>


### PR DESCRIPTION
## Summary
- enable dynamic rendering of character, location, item, language, event and note lists
- add edit and delete handlers for each entity type
- wire modal forms to handle both creation and updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a76f65f5d48325903782ab33fe2301