### PR TITLE
chore: guard DOM lookups

### DIFF
--- a/js/characters.js
+++ b/js/characters.js
@@ -1,6 +1,11 @@
 import { projectData, editingIds } from './state.js';
 import { saveProject } from './editor.js';
 
+function setField(id, value = '') {
+  const el = document.getElementById(id);
+  if (el) el.value = value;
+}
+
 export function renderCharacterList() {
   const list = document.getElementById('characterList');
   if (!list) return;
@@ -26,8 +31,8 @@ export function renderCharacterList() {
 
 export function openCharacterModal() {
   editingIds.character = null;
-  ['charName','charAge','charRace','charClass','charRole','charAppearance','charPersonality','charBackground','charSkills','charRelationships','charTags'].forEach(id => document.getElementById(id).value = '');
-  document.getElementById('characterModal').classList.add('active');
+  ['charName','charAge','charRace','charClass','charRole','charAppearance','charPersonality','charBackground','charSkills','charRelationships','charTags'].forEach(id => setField(id));
+  document.getElementById('characterModal')?.classList.add('active');
 }
 
 export async function saveCharacter() {
@@ -43,7 +48,7 @@ export async function saveCharacter() {
     background: document.getElementById('charBackground').value,
     skills: document.getElementById('charSkills').value,
     relationships: document.getElementById('charRelationships').value,
-    tags: document.getElementById('charTags').value.split(',').map(t => t.trim())
+    tags: document.getElementById('charTags').value.split(',').map(t => t.trim()).filter(Boolean)
   };
 
   if (editingIds.character) {
@@ -63,18 +68,18 @@ export function editCharacter(id) {
   const c = projectData.characters.find(ch => ch.id === id);
   if (!c) return;
   editingIds.character = id;
-  document.getElementById('charName').value = c.name || '';
-  document.getElementById('charAge').value = c.age || '';
-  document.getElementById('charRace').value = c.race || '';
-  document.getElementById('charClass').value = c.class || '';
-  document.getElementById('charRole').value = c.role || '';
-  document.getElementById('charAppearance').value = c.appearance || '';
-  document.getElementById('charPersonality').value = c.personality || '';
-  document.getElementById('charBackground').value = c.background || '';
-  document.getElementById('charSkills').value = c.skills || '';
-  document.getElementById('charRelationships').value = c.relationships || '';
-  document.getElementById('charTags').value = (c.tags || []).join(', ');
-  document.getElementById('characterModal').classList.add('active');
+  setField('charName', c.name);
+  setField('charAge', c.age);
+  setField('charRace', c.race);
+  setField('charClass', c.class);
+  setField('charRole', c.role);
+  setField('charAppearance', c.appearance);
+  setField('charPersonality', c.personality);
+  setField('charBackground', c.background);
+  setField('charSkills', c.skills);
+  setField('charRelationships', c.relationships);
+  setField('charTags', (c.tags || []).join(', '));
+  document.getElementById('characterModal')?.classList.add('active');
 }
 
 export async function deleteCharacter(id) {

--- a/js/main.js
+++ b/js/main.js
@@ -4,7 +4,7 @@ import * as characters from './characters.js';
 import * as world from './world.js';
 
 function closeModal(modalId) {
-  document.getElementById(modalId).classList.remove('active');
+  document.getElementById(modalId)?.classList.remove('active');
 }
 
 Object.assign(window, editor, characters, world, { closeModal });
@@ -13,8 +13,8 @@ async function loadProject() {
   const res = await fetch('/load');
   const data = await res.json();
   Object.assign(projectData, data);
-  document.getElementById('mainText').value = projectData.content || '';
-  document.getElementById('documentTitle').value = projectData.title || '';
+  document.getElementById('mainText')?.value = projectData.content || '';
+  document.getElementById('documentTitle')?.value = projectData.title || '';
   editor.updateWordCount();
   characters.renderCharacterList();
   world.renderLocationList();
@@ -30,8 +30,9 @@ document.querySelectorAll('.nav-item').forEach(item => {
     document.querySelectorAll('.content-panel').forEach(panel => panel.classList.remove('active'));
     this.classList.add('active');
     const route = this.dataset.route;
-    document.getElementById(route).classList.add('active');
-    document.getElementById('crumb').textContent = this.textContent.trim();
+    document.getElementById(route)?.classList.add('active');
+    const crumb = document.getElementById('crumb');
+    if (crumb) crumb.textContent = this.textContent.trim();
   });
 });
 
@@ -42,7 +43,8 @@ document.querySelectorAll('.tab').forEach(tab => {
       document.querySelectorAll('.tab-content').forEach(tc => tc.style.display = 'none');
       this.classList.add('active');
       const tabId = this.dataset.tab;
-      document.getElementById(tabId).style.display = 'block';
+      const tab = document.getElementById(tabId);
+      if (tab) tab.style.display = 'block';
     }
   });
 });
@@ -55,9 +57,9 @@ document.querySelectorAll('.modal').forEach(modal => {
   });
 });
 
-document.getElementById('mainText').addEventListener('input', editor.updateWordCount);
+document.getElementById('mainText')?.addEventListener('input', editor.updateWordCount);
 
-document.getElementById('importFile').addEventListener('change', editor.importProject);
+document.getElementById('importFile')?.addEventListener('change', editor.importProject);
 
 document.addEventListener('keydown', function(e) {
   if ((e.ctrlKey || e.metaKey) && e.key === 's') {


### PR DESCRIPTION
## Summary
- avoid null reference errors in character modal helpers
- make navigation and tab handlers resilient to missing DOM nodes

## Testing
- `npm test`
- `node --check server.js && echo "server check passed"`
- `node --check js/characters.js` *(fails: Cannot use import statement outside a module)*
- `node --check js/main.js` *(fails: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_68a878ccc7d88325b9986ce2f66f2d22