### PR TITLE
Add aria labels to icon-only buttons

### DIFF
--- a/loreloom.html
+++ b/loreloom.html
@@ -10,7 +10,7 @@
   <!-- Topbar -->
   <header class="topbar">
     <div class="left">
-      <button id="sidebarToggle" class="btn" title="Alternar menu">☰</button>
+      <button id="sidebarToggle" class="btn" title="Alternar menu" aria-label="Alternar menu">☰</button>
       <strong>LoreLoom</strong>
       <span class="status-mini"><span class="dot">•</span><span id="status" data-i18n="ready">Pronto</span></span>
     </div>
@@ -80,9 +80,9 @@
             <button class="btn" data-action="formatText" data-arg="bold" title="Negrito"><b>B</b></button>
             <button class="btn" data-action="formatText" data-arg="italic" title="Itálico"><i>I</i></button>
             <button class="btn" data-action="formatText" data-arg="underline" title="Sublinhado"><u>U</u></button>
-            <button class="btn" data-action="insertReference" title="Inserir Referência">[ ]</button>
-            <button class="btn" data-action="insertCharacterRef" title="Personagem">👤</button>
-            <button class="btn" data-action="insertLocationRef" title="Local">🌍</button>
+            <button class="btn" data-action="insertReference" title="Inserir referência" aria-label="Inserir referência">[ ]</button>
+            <button class="btn" data-action="insertCharacterRef" title="Inserir referência de personagem" aria-label="Inserir referência de personagem">👤</button>
+            <button class="btn" data-action="insertLocationRef" title="Inserir referência de local" aria-label="Inserir referência de local">🌍</button>
             <button class="btn btn-secundario" data-action="checkConsistency">✔ Consistência</button>
 
             <!-- NOVOS -->


### PR DESCRIPTION
## Summary
- add aria-label to sidebar toggle button for screen reader support
- label reference, character, and location buttons with aria-labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a885680f9c8325bae8e563299ba6af