### PR TITLE
Improve modal accessibility and focus handling

### DIFF
--- a/js/characters.js
+++ b/js/characters.js
@@ -21,7 +21,7 @@ export function renderCharacterList() {
         ${tags}
       </div>
       <div>
-        <button class="btn" onclick="editCharacter(${c.id})">Editar</button>
+        <button class="btn" onclick="editCharacter(${c.id}, this)">Editar</button>
         <button class="btn btn-danger" onclick="deleteCharacter(${c.id})">Excluir</button>
       </div>
     `;
@@ -29,10 +29,10 @@ export function renderCharacterList() {
   });
 }
 
-export function openCharacterModal() {
+export function openCharacterModal(trigger = document.activeElement) {
   editingIds.character = null;
   ['charName','charAge','charRace','charClass','charRole','charAppearance','charPersonality','charBackground','charSkills','charRelationships','charTags'].forEach(id => setField(id));
-  document.getElementById('characterModal')?.classList.add('active');
+  openModal('characterModal', trigger);
 }
 
 export async function saveCharacter() {
@@ -64,7 +64,7 @@ export async function saveCharacter() {
   console.log('Personagem salvo:', character);
 }
 
-export function editCharacter(id) {
+export function editCharacter(id, trigger = document.activeElement) {
   const c = projectData.characters.find(ch => ch.id === id);
   if (!c) return;
   editingIds.character = id;
@@ -79,7 +79,7 @@ export function editCharacter(id) {
   setField('charSkills', c.skills);
   setField('charRelationships', c.relationships);
   setField('charTags', (c.tags || []).join(', '));
-  document.getElementById('characterModal')?.classList.add('active');
+  openModal('characterModal', trigger);
 }
 
 export async function deleteCharacter(id) {

--- a/js/main.js
+++ b/js/main.js
@@ -4,8 +4,25 @@ import * as characters from './characters.js';
 import * as world from './world.js';
 import { setLanguage } from './i18n.js';
 
+const modalTriggers = {};
+
+function openModal(modalId, trigger) {
+  const modal = document.getElementById(modalId);
+  if (!modal) return;
+  modal.classList.add('active');
+  modalTriggers[modalId] = trigger || document.activeElement;
+  const focusEl = modal.querySelector('input, select, textarea, button');
+  focusEl?.focus();
+}
+
 function closeModal(modalId) {
-  document.getElementById(modalId)?.classList.remove('active');
+  const modal = document.getElementById(modalId);
+  modal?.classList.remove('active');
+  const trigger = modalTriggers[modalId];
+  if (trigger && typeof trigger.focus === 'function') {
+    trigger.focus();
+  }
+  delete modalTriggers[modalId];
 }
 
 function triggerImport() {
@@ -19,7 +36,7 @@ function closeGrammarPanel() {
 
 const localActions = { triggerImport, closeGrammarPanel };
 
-Object.assign(window, editor, characters, world, { closeModal });
+Object.assign(window, editor, characters, world, { openModal, closeModal });
 
 async function loadProject() {
   const res = await fetch('/load');
@@ -74,7 +91,7 @@ document.querySelectorAll('.tab').forEach(tab => {
 document.querySelectorAll('.modal').forEach(modal => {
   modal.addEventListener('click', function(e) {
     if (e.target === this) {
-      this.classList.remove('active');
+      closeModal(this.id);
     }
   });
 });
@@ -107,9 +124,9 @@ document.querySelectorAll('[data-action]').forEach(el => {
     const fn = localActions[action] || window[action];
     if (typeof fn === 'function') {
       if (arg !== null) {
-        fn(arg);
+        fn(arg, el);
       } else {
-        fn();
+        fn(el);
       }
     }
   });

--- a/js/world.js
+++ b/js/world.js
@@ -16,7 +16,7 @@ export function renderLocationList() {
         ${tags}
       </div>
       <div>
-        <button class="btn" onclick="editLocation(${l.id})">Editar</button>
+        <button class="btn" onclick="editLocation(${l.id}, this)">Editar</button>
         <button class="btn btn-danger" onclick="deleteLocation(${l.id})">Excluir</button>
       </div>
     `;
@@ -37,7 +37,7 @@ export function renderItemList() {
         <div style="font-size: 0.9em; color: #64748b;">${[i.type, i.rarity].filter(Boolean).join(' • ')}</div>
       </div>
       <div>
-        <button class="btn" onclick="editItem(${i.id})">Editar</button>
+        <button class="btn" onclick="editItem(${i.id}, this)">Editar</button>
         <button class="btn btn-danger" onclick="deleteItem(${i.id})">Excluir</button>
       </div>
     `;
@@ -56,7 +56,7 @@ export function renderLanguageList() {
       <h3>${l.name}</h3>
       <div style="font-size: 0.9em; color: #64748b;">${l.family || ''}</div>
       <div style="margin-top:8px;">
-        <button class="btn" onclick="editLanguage(${l.id})">Editar</button>
+        <button class="btn" onclick="editLanguage(${l.id}, this)">Editar</button>
         <button class="btn btn-danger" onclick="deleteLanguage(${l.id})">Excluir</button>
       </div>
     `;
@@ -79,7 +79,7 @@ export function renderEventList() {
       <div style=\"font-size: 0.9em; color: #64748b; margin-top: 4px;\">${e.description || ''}</div>
       ${(e.importance ? `<div class="tag">${e.importance}</div>` : '')}
       <div style="margin-top: 8px;">
-        <button class="btn" onclick="editEvent(${e.id})">Editar</button>
+        <button class="btn" onclick="editEvent(${e.id}, this)">Editar</button>
         <button class="btn btn-danger" onclick="deleteEvent(${e.id})">Excluir</button>
       </div>
     `;
@@ -104,7 +104,7 @@ export function renderNoteList() {
       <p style="font-size: 0.9em; margin: 8px 0;">${n.content}</p>
       ${tags}
       <div style="margin-top: 12px;">
-        <button class="btn" onclick="editNote(${n.id})">Editar</button>
+        <button class="btn" onclick="editNote(${n.id}, this)">Editar</button>
         <button class="btn btn-danger" onclick="deleteNote(${n.id})">Excluir</button>
       </div>
     `;
@@ -112,34 +112,34 @@ export function renderNoteList() {
   });
 }
 
-export function openLocationModal() {
+export function openLocationModal(trigger = document.activeElement) {
   editingIds.location = null;
   ['locName','locType','locRegion','locPopulation','locDescription','locRuler','locInterests','locHistory','locTags'].forEach(id => document.getElementById(id).value = '');
-  document.getElementById('locationModal').classList.add('active');
+  openModal('locationModal', trigger);
 }
 
-export function openItemModal() {
+export function openItemModal(trigger = document.activeElement) {
   editingIds.item = null;
   ['itemName','itemType','itemRarity','itemDescription','itemProperties','itemValue','itemWeight','itemHistory','itemLocation'].forEach(id => document.getElementById(id).value = '');
-  document.getElementById('itemModal').classList.add('active');
+  openModal('itemModal', trigger);
 }
 
-export function openLanguageModal() {
+export function openLanguageModal(trigger = document.activeElement) {
   editingIds.language = null;
   ['langName','langFamily','langScript','langSpeakers','langPhonetics','langGrammar','langExamples'].forEach(id => document.getElementById(id).value = '');
-  document.getElementById('languageModal').classList.add('active');
+  openModal('languageModal', trigger);
 }
 
-export function openEventModal() {
+export function openEventModal(trigger = document.activeElement) {
   editingIds.event = null;
   ['eventName','eventDate','eventType','eventLocation','eventDescription','eventCharacters','eventConsequences','eventImportance'].forEach(id => document.getElementById(id).value = '');
-  document.getElementById('eventModal').classList.add('active');
+  openModal('eventModal', trigger);
 }
 
-export function openNoteModal() {
+export function openNoteModal(trigger = document.activeElement) {
   editingIds.note = null;
   ['noteTitle','noteCategory','noteContent','noteTags'].forEach(id => document.getElementById(id).value = '');
-  document.getElementById('noteModal').classList.add('active');
+  openModal('noteModal', trigger);
 }
 
 export async function saveLocation() {
@@ -270,7 +270,7 @@ export async function saveNote() {
   console.log('Nota salva:', note);
 }
 
-export function editLocation(id) {
+export function editLocation(id, trigger = document.activeElement) {
   const l = projectData.locations.find(loc => loc.id === id);
   if (!l) return;
   editingIds.location = id;
@@ -283,7 +283,7 @@ export function editLocation(id) {
   document.getElementById('locInterests').value = l.interests || '';
   document.getElementById('locHistory').value = l.history || '';
   document.getElementById('locTags').value = (l.tags || []).join(', ');
-  document.getElementById('locationModal').classList.add('active');
+  openModal('locationModal', trigger);
 }
 
 export async function deleteLocation(id) {
@@ -292,7 +292,7 @@ export async function deleteLocation(id) {
   renderLocationList();
 }
 
-export function editItem(id) {
+export function editItem(id, trigger = document.activeElement) {
   const i = projectData.items.find(it => it.id === id);
   if (!i) return;
   editingIds.item = id;
@@ -305,7 +305,7 @@ export function editItem(id) {
   document.getElementById('itemWeight').value = i.weight || '';
   document.getElementById('itemHistory').value = i.history || '';
   document.getElementById('itemLocation').value = i.location || '';
-  document.getElementById('itemModal').classList.add('active');
+  openModal('itemModal', trigger);
 }
 
 export async function deleteItem(id) {
@@ -314,7 +314,7 @@ export async function deleteItem(id) {
   renderItemList();
 }
 
-export function editLanguage(id) {
+export function editLanguage(id, trigger = document.activeElement) {
   const l = projectData.languages.find(lang => lang.id === id);
   if (!l) return;
   editingIds.language = id;
@@ -325,7 +325,7 @@ export function editLanguage(id) {
   document.getElementById('langPhonetics').value = l.phonetics || '';
   document.getElementById('langGrammar').value = l.grammar || '';
   document.getElementById('langExamples').value = l.examples || '';
-  document.getElementById('languageModal').classList.add('active');
+  openModal('languageModal', trigger);
 }
 
 export async function deleteLanguage(id) {
@@ -334,7 +334,7 @@ export async function deleteLanguage(id) {
   renderLanguageList();
 }
 
-export function editEvent(id) {
+export function editEvent(id, trigger = document.activeElement) {
   const e = projectData.timeline.find(ev => ev.id === id);
   if (!e) return;
   editingIds.event = id;
@@ -346,7 +346,7 @@ export function editEvent(id) {
   document.getElementById('eventCharacters').value = (e.characters || []).join(', ');
   document.getElementById('eventConsequences').value = e.consequences || '';
   document.getElementById('eventImportance').value = e.importance || '';
-  document.getElementById('eventModal').classList.add('active');
+  openModal('eventModal', trigger);
 }
 
 export async function deleteEvent(id) {
@@ -355,7 +355,7 @@ export async function deleteEvent(id) {
   renderEventList();
 }
 
-export function editNote(id) {
+export function editNote(id, trigger = document.activeElement) {
   const n = projectData.notes.find(nt => nt.id === id);
   if (!n) return;
   editingIds.note = id;
@@ -363,7 +363,7 @@ export function editNote(id) {
   document.getElementById('noteCategory').value = n.category || '';
   document.getElementById('noteContent').value = n.content || '';
   document.getElementById('noteTags').value = (n.tags || []).join(', ');
-  document.getElementById('noteModal').classList.add('active');
+  openModal('noteModal', trigger);
 }
 
 export async function deleteNote(id) {

--- a/loreloom.html
+++ b/loreloom.html
@@ -545,9 +545,9 @@
   </div>
 
   <!-- Modal para Personagem -->
-  <div id="characterModal" class="modal">
+  <div id="characterModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="characterModalTitle">
     <div class="modal-content">
-      <h3>Novo Personagem</h3>
+      <h3 id="characterModalTitle">Novo Personagem</h3>
       
       <div class="form-group">
         <label>Nome</label>
@@ -621,9 +621,9 @@
   </div>
 
   <!-- Modal para Local -->
-  <div id="locationModal" class="modal">
+  <div id="locationModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="locationModalTitle">
     <div class="modal-content">
-      <h3>Novo Local</h3>
+      <h3 id="locationModalTitle">Novo Local</h3>
       
       <div class="form-group">
         <label>Nome do Local</label>
@@ -691,9 +691,9 @@
   </div>
 
   <!-- Modal para Item -->
-  <div id="itemModal" class="modal">
+  <div id="itemModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="itemModalTitle">
     <div class="modal-content">
-      <h3>Novo Item</h3>
+      <h3 id="itemModalTitle">Novo Item</h3>
       
       <div class="form-group">
         <label>Nome do Item</label>
@@ -767,9 +767,9 @@
   </div>
 
   <!-- Modal para Língua -->
-  <div id="languageModal" class="modal">
+  <div id="languageModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="languageModalTitle">
     <div class="modal-content">
-      <h3>Nova Língua</h3>
+      <h3 id="languageModalTitle">Nova Língua</h3>
       
       <div class="form-group">
         <label>Nome da Língua</label>
@@ -815,9 +815,9 @@
   </div>
 
   <!-- Modal para Evento -->
-  <div id="eventModal" class="modal">
+  <div id="eventModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="eventModalTitle">
     <div class="modal-content">
-      <h3>Novo Evento</h3>
+      <h3 id="eventModalTitle">Novo Evento</h3>
       
       <div class="grid grid-2">
         <div class="form-group">
@@ -884,9 +884,9 @@
   </div>
 
   <!-- Modal para Nota -->
-  <div id="noteModal" class="modal">
+  <div id="noteModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="noteModalTitle">
     <div class="modal-content">
-      <h3>Nova Nota</h3>
+      <h3 id="noteModalTitle">Nova Nota</h3>
       
       <div class="form-group">
         <label>Título</label>


### PR DESCRIPTION
## Summary
- add dialog roles and aria attributes to all modal containers
- manage focus when opening modals and restore it on close
- ensure modal triggers pass themselves for proper focus return

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8864759988325bcbe8ed6940b6d0e