### PR TITLE
Handle load errors with fallback

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -39,9 +39,27 @@ const localActions = { triggerImport, closeGrammarPanel };
 Object.assign(window, editor, characters, world, { openModal, closeModal });
 
 async function loadProject() {
-  const res = await fetch('/load');
-  const data = await res.json();
-  Object.assign(projectData, data);
+  let data;
+  try {
+    const res = await fetch('/load');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    data = await res.json();
+  } catch (err) {
+    console.error('Failed to load project', err);
+    document.getElementById('status')?.textContent = 'Erro ao carregar projeto';
+    try {
+      const fallback = await fetch('data.json');
+      if (fallback.ok) {
+        data = await fallback.json();
+        document.getElementById('status')?.textContent = 'Dados locais carregados';
+      }
+    } catch (fallbackErr) {
+      console.error('Fallback load failed', fallbackErr);
+    }
+  }
+  if (data) {
+    Object.assign(projectData, data);
+  }
   const mainTextEl = document.getElementById('mainText');
   if (mainTextEl) mainTextEl.innerHTML = projectData.content || '';
   document.getElementById('documentTitle')?.value = projectData.title || '';


### PR DESCRIPTION
## Summary
- Wrap project load fetch in try/catch and update status on failure
- Retry with local data.json fallback when initial fetch fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a88bd1a5b8832582b8a6a06f0ef7c7