### PR TITLE
Add Joi validation and sanitization for project data and characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "homepage": "https://github.com/Rafium-MS/loreloom#readme",
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "joi": "^17.12.0"
   }
 }

--- a/validation.js
+++ b/validation.js
@@ -1,0 +1,71 @@
+const Joi = require('joi');
+
+const characterSchema = Joi.object({
+  id: Joi.number().integer().required(),
+  name: Joi.string().trim().required(),
+  age: Joi.string().allow('').trim(),
+  race: Joi.string().allow('').trim(),
+  class: Joi.string().allow('').trim(),
+  role: Joi.string().allow('').trim(),
+  appearance: Joi.string().allow('').trim(),
+  personality: Joi.string().allow('').trim(),
+  background: Joi.string().allow('').trim(),
+  skills: Joi.string().allow('').trim(),
+  relationships: Joi.string().allow('').trim(),
+  tags: Joi.array().items(Joi.string().trim()).default([])
+});
+
+const dataSchema = Joi.object({
+  title: Joi.string().trim().allow('').required(),
+  content: Joi.string().trim().allow('').required(),
+  characters: Joi.array().items(characterSchema).required(),
+  locations: Joi.array().required(),
+  items: Joi.array().required(),
+  languages: Joi.array().required(),
+  timeline: Joi.array().required(),
+  notes: Joi.array().required(),
+  economy: Joi.object({
+    currencies: Joi.array().required(),
+    resources: Joi.array().required(),
+    markets: Joi.array().required()
+  }).required(),
+  uiLanguage: Joi.string().trim().required()
+});
+
+function sanitizeCharacter(ch) {
+  return {
+    id: ch.id,
+    name: (ch.name || '').trim(),
+    age: (ch.age || '').trim(),
+    race: (ch.race || '').trim(),
+    class: (ch.class || '').trim(),
+    role: (ch.role || '').trim(),
+    appearance: (ch.appearance || '').trim(),
+    personality: (ch.personality || '').trim(),
+    background: (ch.background || '').trim(),
+    skills: (ch.skills || '').trim(),
+    relationships: (ch.relationships || '').trim(),
+    tags: Array.isArray(ch.tags) ? ch.tags.map(t => t.trim()).filter(Boolean) : []
+  };
+}
+
+function sanitizeData(data) {
+  return {
+    title: (data.title || '').trim(),
+    content: (data.content || '').trim(),
+    characters: Array.isArray(data.characters) ? data.characters.map(sanitizeCharacter) : [],
+    locations: Array.isArray(data.locations) ? data.locations : [],
+    items: Array.isArray(data.items) ? data.items : [],
+    languages: Array.isArray(data.languages) ? data.languages : [],
+    timeline: Array.isArray(data.timeline) ? data.timeline : [],
+    notes: Array.isArray(data.notes) ? data.notes : [],
+    economy: {
+      currencies: Array.isArray(data.economy?.currencies) ? data.economy.currencies : [],
+      resources: Array.isArray(data.economy?.resources) ? data.economy.resources : [],
+      markets: Array.isArray(data.economy?.markets) ? data.economy.markets : []
+    },
+    uiLanguage: (data.uiLanguage || 'pt').trim()
+  };
+}
+
+module.exports = { characterSchema, dataSchema, sanitizeCharacter, sanitizeData };


### PR DESCRIPTION
## Summary
- add Joi schemas and sanitizers for project data and character objects
- validate `/save` and `/characters` routes with Joi and return 400 for invalid data
- include Joi dependency in package.json

## Testing
- `npm test`
- `npm install joi@17` (fails: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68a88f20e2ac83258f9e2f844734da59