### PR TITLE
feat: add electron startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Inicie o servidor:
 npm start
 ```
 
+Para abrir a interface como um aplicativo desktop via Electron:
+```bash
+npm run start:electron
+```
+
 O servidor escutará na porta definida pela variável `PORT` (padrão `3000`).
 Por padrão os dados são armazenados em um arquivo SQLite local (`loreloom.db`).
 Para uso em produção defina `DATABASE_URL` apontando para um banco PostgreSQL compatível antes de iniciar o servidor.
@@ -42,6 +47,7 @@ Todas as rotas aceitam e retornam JSON (exceto a rota raiz que serve um arquivo 
 | Comando              | Descrição                                               |
 |---------------------|---------------------------------------------------------|
 | `npm start`         | Inicia o servidor Express.                              |
+| `npm run start:electron` | Executa o aplicativo usando Electron.                |
 | `npm test`          | Executa os testes (atualmente apenas um placeholder).   |
 | `npm run db:init`   | Cria o banco de dados e importa `data.json` se existir. |
 | `npm run build:css` | Gera `public/css/bundle.css` a partir dos imports CSS.  |

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "loreloom",
   "version": "1.0.0",
   "description": "",
-  "main": "loreloom.html",
+  "main": "electron.js",
   "scripts": {
     "start": "node server.js",
-    "start:electron": "electronn electron.js",
+    "start:electron": "electron electron.js",
     "test": "node --test",
     "build:css": "node build-css.js",
     "db:init": "node scripts/init-db.js"


### PR DESCRIPTION
## Summary
- fix electron start script and main entry
- document desktop startup instructions

## Testing
- `npm test` *(fails: 1 fail, 2 pass)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8208a5608325a4afa855dc991c0d