### PR TITLE
Add tests for os network interfaces route

### DIFF
--- a/test/os.test.js
+++ b/test/os.test.js
@@ -1,0 +1,44 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const express = require('express');
+const os = require('node:os');
+
+// store original function
+const originalNetworkInterfaces = os.networkInterfaces;
+
+test('GET / returns expected network interfaces', async () => {
+  const mockData = {
+    lo: [
+      { address: '127.0.0.1', family: 'IPv4', internal: true }
+    ],
+    en0: [
+      { address: '192.168.0.10', family: 'IPv4', internal: false },
+      { address: 'fe80::1', family: 'IPv6', internal: false }
+    ],
+    wlan0: [
+      { address: '10.0.0.5', family: 'IPv4', internal: false }
+    ]
+  };
+
+  os.networkInterfaces = () => mockData;
+
+  let server;
+  try {
+    const router = require('../routes/os');
+    const app = express();
+    app.use('/', router);
+    server = app.listen(0);
+    const base = `http://localhost:${server.address().port}`;
+
+    const res = await fetch(`${base}/`);
+    assert.equal(res.status, 200);
+    const json = await res.json();
+    assert.deepStrictEqual(json, [
+      { name: 'en0', address: '192.168.0.10' },
+      { name: 'wlan0', address: '10.0.0.5' }
+    ]);
+  } finally {
+    if (server) server.close();
+    os.networkInterfaces = originalNetworkInterfaces;
+  }
+});


### PR DESCRIPTION
## Summary
- add test verifying `/` of os router returns expected network interfaces

## Testing
- `node --test test/os.test.js test/data.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68ac958ba2d48325b600aec85efd2e44