### PR TITLE
refactor: centralize reference insertion

### DIFF
--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -49,11 +49,11 @@ export function insertReference() {
   updateWordCount();
 }
 
-export function insertCharacterRef() {
+export function insertRef(type) {
   const selection = window.getSelection();
   if (!selection.rangeCount) return;
   const range = selection.getRangeAt(0);
-  const node = document.createTextNode('[personagem]');
+  const node = document.createTextNode(`[${type}]`);
   range.insertNode(node);
   range.setStartAfter(node);
   range.collapse(true);
@@ -62,17 +62,12 @@ export function insertCharacterRef() {
   updateWordCount();
 }
 
+export function insertCharacterRef() {
+  insertRef('personagem');
+}
+
 export function insertLocationRef() {
-  const selection = window.getSelection();
-  if (!selection.rangeCount) return;
-  const range = selection.getRangeAt(0);
-  const node = document.createTextNode('[local]');
-  range.insertNode(node);
-  range.setStartAfter(node);
-  range.collapse(true);
-  selection.removeAllRanges();
-  selection.addRange(range);
-  updateWordCount();
+  insertRef('local');
 }
 
 export function updateWordCount() {

--- a/public/loreloom.html
+++ b/public/loreloom.html
@@ -83,8 +83,8 @@
             <button class="btn" data-action="formatText" data-arg="underline" title="Sublinhado"><u>U</u></button>
             <button class="btn" data-action="formatText" data-arg="strikethrough" title="Riscado"><s>S</s></button>
             <button class="btn" data-action="insertReference" title="Inserir referência" aria-label="Inserir referência">[ ]</button>
-            <button class="btn" data-action="insertCharacterRef" title="Inserir referência de personagem" aria-label="Inserir referência de personagem">👤</button>
-            <button class="btn" data-action="insertLocationRef" title="Inserir referência de local" aria-label="Inserir referência de local">🌍</button>
+            <button class="btn" data-action="insertRef" data-arg="personagem" title="Inserir referência de personagem" aria-label="Inserir referência de personagem">👤</button>
+            <button class="btn" data-action="insertRef" data-arg="local" title="Inserir referência de local" aria-label="Inserir referência de local">🌍</button>
             <button class="btn btn-secundario" data-action="checkConsistency">✔ Consistência</button>
 
             <!-- NOVOS -->


### PR DESCRIPTION
## Summary
- add generic `insertRef` helper for inserting bracketed references
- wrap character and location insertion around the generic helper
- wire toolbar buttons to pass reference type through `data-arg`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68acc4729c4c832593ead6fe285f7d2e