### PR TITLE
Add save status helper for documents

### DIFF
--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -103,7 +103,7 @@ export async function saveProject() {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(projectData)
   });
-  document.getElementById('saveStatus').textContent = 'Salvo ' + new Date().toLocaleTimeString();
+  setSaveStatus('Salvo ' + new Date().toLocaleTimeString());
   console.log('Projeto salvo:', projectData);
 }
 

--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -46,6 +46,13 @@ function ensureProject(name) {
 
 
 
+function setSaveStatus(message) {
+  const el = document.getElementById('saveStatus');
+  if (el) {
+    el.textContent = message;
+  }
+}
+
 function persistProject() {
   const map = loadProjectsMap();
   map[slugify(currentProjectName)] = projectData;


### PR DESCRIPTION
## Summary
- add global `setSaveStatus` helper to update the save indicator
- use `setSaveStatus` in save workflow to prevent reference errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ae043c87f483259079071e83adfa5f