### PR TITLE
Ensure data table auto-initializes before reads/writes

### DIFF
--- a/services/db.js
+++ b/services/db.js
@@ -3,6 +3,14 @@ const cache = require('./cache');
 const dataRepository = require('../repositories/dataRepository');
 
 const CACHE_KEY = 'data';
+let initialized = false;
+
+async function ensureInit() {
+  if (!initialized) {
+    await init();
+    initialized = true;
+  }
+}
 
 function getDefaultData() {
   return {
@@ -26,9 +34,11 @@ async function init() {
       table.text('json');
     });
   }
+  initialized = true;
 }
 
 async function readData() {
+  await ensureInit();
   const cached = cache.get(CACHE_KEY);
   if (cached) return cached;
 
@@ -52,6 +62,7 @@ async function readData() {
 }
 
 async function writeData(data) {
+  await ensureInit();
   const entries = Object.entries(data);
   for (const [key, value] of entries) {
     await dataRepository.upsert(key, value);

--- a/test/db.test.js
+++ b/test/db.test.js
@@ -39,15 +39,13 @@ test.afterEach(async () => {
 });
 
 test('readData creates default structure when the database is empty', async () => {
-  const { init, readData } = require(dbModulePath);
-  await init();
+  const { readData } = require(dbModulePath);
   const data = await readData();
   assert.deepStrictEqual(data, defaultData);
 });
 
 test('writeData persists and readData retrieves the data', async () => {
-  const { init, readData, writeData } = require(dbModulePath);
-  await init();
+  const { readData, writeData } = require(dbModulePath);
   const payload = {
     title: 'Title',
     content: 'Content',


### PR DESCRIPTION
## Summary
- avoid `no such table: data_entries` errors by lazily creating the `data_entries` table
- update db tests to rely on implicit initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0b3c636348325b584ce289599de2e