### PR TITLE
feat: centralize async error handling

### DIFF
--- a/middlewares/asyncHandler.js
+++ b/middlewares/asyncHandler.js
@@ -1,0 +1,3 @@
+module.exports = (fn) => (req, res, next) => {
+  Promise.resolve(fn(req, res, next)).catch(next);
+};

--- a/routes/characters.js
+++ b/routes/characters.js
@@ -1,23 +1,23 @@
 const express = require('express');
 const { characterSchema } = require('../validation');
 const { getAllCharacters, addCharacter } = require('../services/characters');
+const asyncHandler = require('../middlewares/asyncHandler');
 
 const router = express.Router();
 
-router.get('/', async (req, res) => {
-  try {
+router.get(
+  '/',
+  asyncHandler(async (req, res) => {
     const limit = parseInt(req.query.limit, 10) || 20;
     const cursor = req.query.cursor ? parseInt(req.query.cursor, 10) : undefined;
     const result = await getAllCharacters({ limit, cursor });
     res.json(result);
-  } catch (err) {
-    console.error('Error loading characters:', err);
-    res.status(500).json({ error: 'Failed to load characters' });
-  }
-});
+  })
+);
 
-router.post('/', async (req, res) => {
-  try {
+router.post(
+  '/',
+  asyncHandler(async (req, res) => {
     const { error, value } = characterSchema.validate(req.body);
     if (error) {
       return res.status(400).json(error);
@@ -25,10 +25,7 @@ router.post('/', async (req, res) => {
 
     const newCharacter = await addCharacter(value);
     res.status(201).json(newCharacter);
-  } catch (err) {
-    console.error('Error saving character:', err);
-    res.status(500).json({ error: 'Failed to save character' });
-  }
-});
+  })
+);
 
 module.exports = router;

--- a/routes/data.js
+++ b/routes/data.js
@@ -1,41 +1,36 @@
 const express = require('express');
 const { dataSchema } = require('../validation');
 const { readData, writeData } = require('../services/db');
+const asyncHandler = require('../middlewares/asyncHandler');
 
 const router = express.Router();
 
-router.post('/save', async (req, res) => {
-  try {
+router.post(
+  '/save',
+  asyncHandler(async (req, res) => {
     const { error, value } = dataSchema.validate(req.body);
     if (error) {
       return res.status(400).json(error);
     }
     await writeData(value);
     res.json({ status: 'ok' });
-  } catch (err) {
-    console.error('Error saving data:', err);
-    res.status(500).json({ error: 'Failed to save data' });
-  }
-});
+  })
+);
 
-router.get('/load', async (_req, res) => {
-  try {
+router.get(
+  '/load',
+  asyncHandler(async (_req, res) => {
     const data = await readData();
     res.json(data);
-  } catch (err) {
-    console.error('Error loading data:', err);
-    res.status(500).json({ error: 'Failed to load data' });
-  }
-});
+  })
+);
 
-router.get('/data.json', async (_req, res) => {
-  try {
+router.get(
+  '/data.json',
+  asyncHandler(async (_req, res) => {
     const data = await readData();
     res.json(data);
-  } catch (err) {
-    console.error('Error loading data:', err);
-    res.status(500).json({ error: 'Failed to load data' });
-  }
-});
+  })
+);
 
 module.exports = router;

--- a/routes/os.js
+++ b/routes/os.js
@@ -1,21 +1,25 @@
 const express = require('express');
 const os = require('os');
+const asyncHandler = require('../middlewares/asyncHandler');
 
 const router = express.Router();
 
-router.get('/', (_req, res) => {
-  const nets = os.networkInterfaces();
-  const results = [];
+router.get(
+  '/',
+  asyncHandler(async (_req, res) => {
+    const nets = os.networkInterfaces();
+    const results = [];
 
-  for (const name of Object.keys(nets)) {
-    for (const net of nets[name]) {
-      if (net.family === 'IPv4' && !net.internal) {
-        results.push({ name, address: net.address });
+    for (const name of Object.keys(nets)) {
+      for (const net of nets[name]) {
+        if (net.family === 'IPv4' && !net.internal) {
+          results.push({ name, address: net.address });
+        }
       }
     }
-  }
 
-  res.json(results);
-});
+    res.json(results);
+  })
+);
 
 module.exports = router;

--- a/routes/root.js
+++ b/routes/root.js
@@ -1,10 +1,14 @@
 const express = require('express');
 const path = require('path');
+const asyncHandler = require('../middlewares/asyncHandler');
 
 const router = express.Router();
 
-router.get('/', (_req, res) => {
-  res.sendFile(path.join(__dirname, '..', 'public', 'loreloom.html'));
-});
+router.get(
+  '/',
+  asyncHandler(async (_req, res) => {
+    res.sendFile(path.join(__dirname, '..', 'public', 'loreloom.html'));
+  })
+);
 
 module.exports = router;

--- a/server.js
+++ b/server.js
@@ -24,6 +24,14 @@ app.use('/os', osRouter);
 app.use('/', dataRouter);
 app.use('/', rootRouter);
 
+// Global error handler
+app.use((err, req, res, _next) => {
+  console.error(err);
+  res
+    .status(err.status || 500)
+    .json({ error: err.message || 'Internal Server Error' });
+});
+
 app.listen(port, () => {
   console.log('LoreLoom server running at:');
   console.log(`  Local:   http://localhost:${port}`);


### PR DESCRIPTION
## Summary
- add asyncHandler middleware to wrap route handlers
- use asyncHandler in all routers
- implement global JSON error handler in Express server

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b0b890f1b48325a9fa1f7a1992b192