### PR TITLE
refactor: modularize modals and navigation

### DIFF
--- a/public/js/modals.js
+++ b/public/js/modals.js
@@ -1,0 +1,35 @@
+const modalTriggers = {};
+
+export async function loadModals() {
+  const res = await fetch('/partials/modals.html');
+  if (res.ok) {
+    const html = await res.text();
+    document.body.insertAdjacentHTML('beforeend', html);
+    document.querySelectorAll('.modal').forEach((modal) => {
+      modal.addEventListener('click', function (e) {
+        if (e.target === this) {
+          closeModal(this.id);
+        }
+      });
+    });
+  }
+}
+
+export function openModal(modalId, trigger) {
+  const modal = document.getElementById(modalId);
+  if (!modal) return;
+  modal.classList.add('active');
+  modalTriggers[modalId] = trigger || document.activeElement;
+  const focusEl = modal.querySelector('input, select, textarea, button');
+  focusEl?.focus();
+}
+
+export function closeModal(modalId) {
+  const modal = document.getElementById(modalId);
+  modal?.classList.remove('active');
+  const trigger = modalTriggers[modalId];
+  if (trigger && typeof trigger.focus === 'function') {
+    trigger.focus();
+  }
+  delete modalTriggers[modalId];
+}

--- a/public/js/navigation.js
+++ b/public/js/navigation.js
@@ -1,0 +1,45 @@
+export function initNavigation() {
+  document.querySelectorAll('.nav-item').forEach((item) => {
+    item.addEventListener('click', function (e) {
+      e.stopPropagation();
+      document
+        .querySelectorAll('.nav-item')
+        .forEach((nav) => nav.classList.remove('active'));
+      document
+        .querySelectorAll('.content-panel')
+        .forEach((panel) => panel.classList.remove('active'));
+      this.classList.add('active');
+      const route = this.dataset.route;
+      document.getElementById(route)?.classList.add('active');
+      const crumb = document.getElementById('crumb');
+      if (crumb) {
+        crumb.setAttribute('data-i18n', this.getAttribute('data-i18n') || '');
+        const label = this.classList.contains('has-submenu')
+          ? this.childNodes[0].textContent.trim()
+          : this.textContent.trim();
+        crumb.textContent = label;
+      }
+    });
+  });
+
+  document.querySelectorAll('.tab').forEach((tab) => {
+    tab.addEventListener('click', function () {
+      if (this.closest('#world')) {
+        document
+          .querySelectorAll('.tab')
+          .forEach((t) => t.classList.remove('active'));
+        document
+          .querySelectorAll('.tab-content')
+          .forEach((tc) => (tc.style.display = 'none'));
+        this.classList.add('active');
+        const tabId = this.dataset.tab;
+        const tabContent = document.getElementById(tabId);
+        if (tabContent) tabContent.style.display = 'block';
+      }
+    });
+  });
+
+  document.getElementById('sidebarToggle')?.addEventListener('click', () => {
+    document.querySelector('.app')?.classList.toggle('collapsed');
+  });
+}


### PR DESCRIPTION
## Summary
- extract modal logic into `modals.js`
- move navigation listeners to `navigation.js`
- update `main.js` imports and global exposure

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b0bdf6a5cc83259b35ad20bfc00181