### PR TITLE
feat: centralize environment configuration

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,10 @@
+try {
+  const dotenv = await import('dotenv');
+  dotenv.default.config();
+} catch (err) {
+  // dotenv not installed, ignore
+}
+
+export const PORT = process.env.PORT || 3000;
+export const DATABASE_URL = process.env.DATABASE_URL;
+export const DATABASE_FILE = process.env.DATABASE_FILE;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/Rafium-MS/loreloom#readme",
   "dependencies": {
+    "dotenv": "^16.4.5",
     "express": "^4.18.2",
     "knex": "^3.1.0",
     "morgan": "^1.10.1",

--- a/server.js
+++ b/server.js
@@ -8,12 +8,13 @@ import charactersRouter from './routes/characters.js';
 import dataRouter from './routes/data.js';
 import osRouter from './routes/os.js';
 import rootRouter from './routes/root.js';
+import { PORT } from './config/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const app = express();
-const port = process.env.PORT || 3000;
+const port = PORT;
 
 // Middlewares
 app.use(morgan('dev'));

--- a/services/knex.js
+++ b/services/knex.js
@@ -1,15 +1,15 @@
 import knex from 'knex';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { DATABASE_URL, DATABASE_FILE } from '../config/index.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const dbFile =
-  process.env.DATABASE_FILE || path.join(__dirname, '..', 'loreloom.db');
+const dbFile = DATABASE_FILE || path.join(__dirname, '..', 'loreloom.db');
 
-const config = process.env.DATABASE_URL
-  ? { client: 'pg', connection: process.env.DATABASE_URL }
+const config = DATABASE_URL
+  ? { client: 'pg', connection: DATABASE_URL }
   : {
       client: 'sqlite3',
       connection: { filename: dbFile },


### PR DESCRIPTION
## Summary
- centralize environment variables in new `config` module and load optional `.env`
- use configured values in server startup and knex setup
- declare `dotenv` dependency for environment file support

## Testing
- `npm test`
- `npm run lint` *(fails: ReferenceError: module is not defined in ES module scope)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c2d8c0948325b4f680eb36bf89a2