### PR TITLE
Integrate editor and universe creator

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,57 @@
-import React from 'react';
+import React, { useState } from 'react';
 import ThemeToggle from './ui/ThemeToggle';
+import FictionEditor from './fantasy-fiction-editor';
+import UniverseCreator from './universe-creator';
 import logoUrl from '../assets/logo.png';
 
 const App: React.FC = () => {
+  const [page, setPage] = useState<'editor' | 'universe'>('editor');
+
   return (
     <div style={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column' }}>
-      <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '12px 16px', borderBottom: '1px solid var(--border)' }}>
+      <header
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '12px 16px',
+          borderBottom: '1px solid var(--border)',
+        }}
+      >
         <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
           <img src={logoUrl} alt="LoreLoom" height={24} />
           <strong>LoreLoom</strong>
         </div>
-        <ThemeToggle />
-      </header>
-      <main style={{ flex: 1, padding: 16 }}>
-        <div className="token-card" style={{ padding: 16 }}>
-          <h1 style={{ margin: 0, marginBottom: 8 }}>Bem-vindo 👋</h1>
-          <p style={{ margin: 0, opacity: 0.9 }}>
-            Estrutura React inicial criada com Vite + TypeScript. Edite o arquivo <code>src/App.tsx</code> e adicione suas páginas/componentes.
-          </p>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+          <button
+            onClick={() => setPage('editor')}
+            style={{
+              background: 'none',
+              border: 'none',
+              padding: '4px 8px',
+              cursor: 'pointer',
+              fontWeight: page === 'editor' ? 'bold' : 'normal',
+            }}
+          >
+            Editor
+          </button>
+          <button
+            onClick={() => setPage('universe')}
+            style={{
+              background: 'none',
+              border: 'none',
+              padding: '4px 8px',
+              cursor: 'pointer',
+              fontWeight: page === 'universe' ? 'bold' : 'normal',
+            }}
+          >
+            Universo
+          </button>
+          <ThemeToggle />
         </div>
+      </header>
+      <main style={{ flex: 1, overflow: 'auto' }}>
+        {page === 'editor' ? <FictionEditor /> : <UniverseCreator />}
       </main>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add navigation in App to switch between fiction editor and universe creator pages

## Testing
- `npm run typecheck` (fails: JSX elements implicitly have type 'any')
- `npm run build` (fails: vite: not found)

------
https://chatgpt.com/codex/tasks/task_e_68b1f6a6d9688325ba6d6ceefcfb5fc3