### PR TITLE
Fix missing imports in editor component

### DIFF
--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Bold, Italic, Underline, Quote, List, AlignLeft, AlignCenter, AlignRight, Save, FileText, BookOpen, Users, MapPin, Sparkles, Eye, EyeOff, PlusCircle, X, Edit3, Scroll } from 'lucide-react';
+import { getCharacters, saveCharacter, getLocations, saveLocation } from '../dataStore';
+import { createProject, exportToMarkdown } from '../project';
 
 const FictionEditor = () => {
   const [content, setContent] = useState('');


### PR DESCRIPTION
## Summary
- import getCharacters/getLocations and save helpers
- import project utilities for markdown export

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: numerous TS7026/TS2307 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fe7351f883259ef2ef57a68590ba