### PR TITLE
Implement DOCX export, Markdown import and persistent deletions

### DIFF
--- a/dataStore.ts
+++ b/dataStore.ts
@@ -54,6 +54,12 @@ export async function saveCharacter(char: {id: number; name: string; description
   await persist();
 }
 
+export async function removeCharacter(id: number) {
+  const db = await getDB();
+  db.run('DELETE FROM characters WHERE id = ?', [id]);
+  await persist();
+}
+
 export async function getLocations() {
   const db = await getDB();
   const res: any[] = [];
@@ -68,5 +74,11 @@ export async function getLocations() {
 export async function saveLocation(loc: {id: number; name: string; description: string; type: string;}) {
   const db = await getDB();
   db.run('INSERT OR REPLACE INTO locations (id, name, description, type) VALUES (?, ?, ?, ?)', [loc.id, loc.name, loc.description, loc.type]);
+  await persist();
+}
+
+export async function removeLocation(id: number) {
+  const db = await getDB();
+  db.run('DELETE FROM locations WHERE id = ?', [id]);
   await persist();
 }

--- a/project.ts
+++ b/project.ts
@@ -1,3 +1,5 @@
+import { Document, Packer, Paragraph, HeadingLevel } from 'docx';
+
 export interface Character {
   id: number;
   name: string;
@@ -48,11 +50,77 @@ export function exportToMarkdown(project: Project): string {
 }
 
 export async function exportToDocx(_project: Project): Promise<Blob | null> {
-  // Placeholder: real implementation would use the docx package
-  return null;
+  try {
+    const doc = new Document({
+      sections: [
+        {
+          properties: {},
+          children: [
+            new Paragraph({ text: _project.title, heading: HeadingLevel.TITLE }),
+            ..._project.chapters.flatMap((ch, i) => [
+              new Paragraph({
+                text: `Capítulo ${i + 1}: ${ch.title}`,
+                heading: HeadingLevel.HEADING_1,
+              }),
+              ...ch.scenes.flatMap((sc) => [
+                new Paragraph({ text: sc.title, heading: HeadingLevel.HEADING_2 }),
+                new Paragraph(sc.text),
+              ]),
+            ]),
+          ],
+        },
+      ],
+    });
+    return await Packer.toBlob(doc);
+  } catch {
+    return null;
+  }
 }
 
 export function importFromMarkdown(_markdown: string): Project | null {
-  // Placeholder for future parser
-  return null;
+  const lines = _markdown.split(/\r?\n/);
+  if (!lines[0]?.startsWith('#')) return null;
+  const project: Project = {
+    id: Date.now(),
+    title: lines[0].replace(/^#\s*/, '').trim(),
+    chapters: [],
+    characters: [],
+    locations: [],
+  };
+
+  let currentChapter: Chapter | null = null;
+  let currentScene: Scene | null = null;
+  let chapterId = 1;
+  let sceneId = 1;
+  let buffer: string[] = [];
+
+  const flushScene = () => {
+    if (currentChapter && currentScene) {
+      currentScene.text = buffer.join('\n').trim();
+      currentChapter.scenes.push(currentScene);
+    }
+    buffer = [];
+    currentScene = null;
+  };
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.startsWith('## ')) {
+      flushScene();
+      const match = line.match(/^##\s+(?:Capítulo\s+\d+:\s+)?(.+)$/);
+      const title = match ? match[1].trim() : line.substring(2).trim();
+      currentChapter = { id: chapterId++, title, scenes: [] };
+      project.chapters.push(currentChapter);
+    } else if (line.startsWith('### ')) {
+      flushScene();
+      if (!currentChapter) continue;
+      const title = line.substring(4).trim();
+      currentScene = { id: sceneId++, title, text: '' };
+    } else if (currentScene) {
+      buffer.push(line);
+    }
+  }
+
+  flushScene();
+  return project;
 }

--- a/src/hooks/useCharacters.ts
+++ b/src/hooks/useCharacters.ts
@@ -46,9 +46,13 @@ export function useCharacters() {
     [load]
   );
 
-  const removeCharacter = useCallback((id: number) => {
-    dispatch({ type: 'remove', payload: id });
-  }, []);
+  const removeCharacter = useCallback(
+    async (id: number) => {
+      await dataStore.removeCharacter(id);
+      await load();
+    },
+    [load]
+  );
 
   return { characters, saveCharacter, removeCharacter, refresh: load };
 }

--- a/src/hooks/useLocations.ts
+++ b/src/hooks/useLocations.ts
@@ -46,9 +46,13 @@ export function useLocations() {
     [load]
   );
 
-  const removeLocation = useCallback((id: number) => {
-    dispatch({ type: 'remove', payload: id });
-  }, []);
+  const removeLocation = useCallback(
+    async (id: number) => {
+      await dataStore.removeLocation(id);
+      await load();
+    },
+    [load]
+  );
 
   return { locations, saveLocation, removeLocation, refresh: load };
 }


### PR DESCRIPTION
## Summary
- implement DOCX export via docx library and markdown import parser
- add persistent removal functions for characters and locations
- update hooks to use database-backed deletion

## Testing
- `npm install docx@^8.5.0` (fails: 403 Forbidden)
- `npm install` (fails: 403 Forbidden)
- `npm run typecheck` (fails: missing module declarations)


------
https://chatgpt.com/codex/tasks/task_e_68b2125fc83c83258f6d8b0d1118fce5