### PR TITLE
feat: add labels and validation to forms

### DIFF
--- a/src/editor/CharacterForm.tsx
+++ b/src/editor/CharacterForm.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTheme } from '../ui/ThemeProvider';
 
 interface CharacterFormProps {
@@ -10,31 +10,70 @@ interface CharacterFormProps {
 const CharacterForm: React.FC<CharacterFormProps> = ({ newCharacter, setNewCharacter, addCharacter }) => {
   const { theme } = useTheme();
   const isDark = theme === 'dark';
+  const [errors, setErrors] = useState({ name: '', role: '', description: '' });
+
+  const handleAdd = () => {
+    const newErrors = {
+      name: newCharacter.name.trim() ? '' : 'Nome é obrigatório',
+      role: newCharacter.role.trim() ? '' : 'Papel é obrigatório',
+      description: newCharacter.description.trim() ? '' : 'Descrição é obrigatória'
+    };
+    setErrors(newErrors);
+    if (Object.values(newErrors).some(Boolean)) return;
+    addCharacter();
+  };
 
   return (
     <div className={`p-3 rounded-lg border ${isDark ? 'border-gray-600 bg-gray-700' : 'border-gray-200 bg-gray-50'}`}>
-      <input
-        type="text"
-        placeholder="Nome do personagem"
-        value={newCharacter.name}
-        onChange={(e) => setNewCharacter({ ...newCharacter, name: e.target.value })}
-        className={`w-full p-2 mb-2 border rounded ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
-      />
-      <input
-        type="text"
-        placeholder="Papel/Função"
-        value={newCharacter.role}
-        onChange={(e) => setNewCharacter({ ...newCharacter, role: e.target.value })}
-        className={`w-full p-2 mb-2 border rounded ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
-      />
-      <textarea
-        placeholder="Descrição e características"
-        value={newCharacter.description}
-        onChange={(e) => setNewCharacter({ ...newCharacter, description: e.target.value })}
-        className={`w-full p-2 mb-2 border rounded h-20 ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
-      />
+      <div className="mb-2">
+        <label htmlFor="character-name" className="block text-sm mb-1">
+          Nome do personagem
+        </label>
+        <input
+          id="character-name"
+          type="text"
+          value={newCharacter.name}
+          onChange={(e) => {
+            setNewCharacter({ ...newCharacter, name: e.target.value });
+            if (errors.name) setErrors({ ...errors, name: '' });
+          }}
+          className={`w-full p-2 border rounded ${errors.name ? 'border-red-500' : isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
+        />
+        {errors.name && <p className="text-red-500 text-sm mt-1">{errors.name}</p>}
+      </div>
+      <div className="mb-2">
+        <label htmlFor="character-role" className="block text-sm mb-1">
+          Papel/Função
+        </label>
+        <input
+          id="character-role"
+          type="text"
+          value={newCharacter.role}
+          onChange={(e) => {
+            setNewCharacter({ ...newCharacter, role: e.target.value });
+            if (errors.role) setErrors({ ...errors, role: '' });
+          }}
+          className={`w-full p-2 border rounded ${errors.role ? 'border-red-500' : isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
+        />
+        {errors.role && <p className="text-red-500 text-sm mt-1">{errors.role}</p>}
+      </div>
+      <div className="mb-2">
+        <label htmlFor="character-description" className="block text-sm mb-1">
+          Descrição e características
+        </label>
+        <textarea
+          id="character-description"
+          value={newCharacter.description}
+          onChange={(e) => {
+            setNewCharacter({ ...newCharacter, description: e.target.value });
+            if (errors.description) setErrors({ ...errors, description: '' });
+          }}
+          className={`w-full p-2 border rounded h-20 ${errors.description ? 'border-red-500' : isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
+        />
+        {errors.description && <p className="text-red-500 text-sm mt-1">{errors.description}</p>}
+      </div>
       <button
-        onClick={addCharacter}
+        onClick={handleAdd}
         className="w-full bg-purple-600 text-white p-2 rounded hover:bg-purple-700"
       >
         Adicionar

--- a/src/editor/Sidebar.tsx
+++ b/src/editor/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Users, MapPin, BookOpen, Edit3, PlusCircle, X, Sparkles, Link2 } from 'lucide-react';
 import { useTheme } from '../ui/ThemeProvider';
 import CharacterForm from './CharacterForm';
@@ -83,6 +83,52 @@ const Sidebar: React.FC<SidebarProps> = ({
   const { theme } = useTheme();
   const isDark = theme === 'dark';
   const isFocus = theme === 'focus';
+  const [locationErrors, setLocationErrors] = useState({ name: '', type: '', description: '' });
+  const [plotErrors, setPlotErrors] = useState({ title: '', chapter: '', description: '' });
+  const [subplotErrors, setSubplotErrors] = useState({ title: '', description: '' });
+  const [relationErrors, setRelationErrors] = useState({ characterId: '', locationId: '' });
+
+  const handleAddLocation = () => {
+    const errors = {
+      name: newLocation.name.trim() ? '' : 'Nome é obrigatório',
+      type: newLocation.type.trim() ? '' : 'Tipo é obrigatório',
+      description: newLocation.description.trim() ? '' : 'Descrição é obrigatória'
+    };
+    setLocationErrors(errors);
+    if (Object.values(errors).some(Boolean)) return;
+    addLocation();
+  };
+
+  const handleAddPlotPoint = () => {
+    const errors = {
+      title: newPlotPoint.title.trim() ? '' : 'Título é obrigatório',
+      chapter: newPlotPoint.chapter.trim() ? '' : 'Capítulo é obrigatório',
+      description: newPlotPoint.description.trim() ? '' : 'Descrição é obrigatória'
+    };
+    setPlotErrors(errors);
+    if (Object.values(errors).some(Boolean)) return;
+    addPlotPoint();
+  };
+
+  const handleAddSubplot = () => {
+    const errors = {
+      title: newSubplot.title.trim() ? '' : 'Título é obrigatório',
+      description: newSubplot.description.trim() ? '' : 'Descrição é obrigatória'
+    };
+    setSubplotErrors(errors);
+    if (Object.values(errors).some(Boolean)) return;
+    addSubplot();
+  };
+
+  const handleAddRelation = () => {
+    const errors = {
+      characterId: newRelation.characterId.trim() ? '' : 'Personagem é obrigatório',
+      locationId: newRelation.locationId.trim() ? '' : 'Local é obrigatório'
+    };
+    setRelationErrors(errors);
+    if (Object.values(errors).some(Boolean)) return;
+    addRelation();
+  };
 
   return (
     <div className={`w-80 border-r flex flex-col`} style={{ borderColor: 'var(--border)', background: 'var(--panel)' }}>
@@ -146,7 +192,7 @@ const Sidebar: React.FC<SidebarProps> = ({
               <div>
                 <h3 className="font-semibold mt-4">Histórico</h3>
                 <ul className="mt-2 space-y-1 text-sm">
-                  {history.map((h, idx) => (
+                  {history.map((h: any, idx: number) => (
                     <li key={h.timestamp}>
                       <button onClick={() => loadVersion(h)} className="text-purple-600 hover:underline">
                         Versão {idx + 1}
@@ -180,7 +226,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             )}
 
             <div className="space-y-3">
-              {characters.map(char => (
+              {characters.map((char: any) => (
                 <div key={char.id} className={`p-3 rounded-lg border ${isDark ? 'border-gray-600 bg-gray-700' : 'border-gray-200 bg-gray-50'}`}>
                   <div className="flex justify-between items-start">
                     <div className="flex-1">
@@ -215,28 +261,49 @@ const Sidebar: React.FC<SidebarProps> = ({
 
             {showLocationForm && (
               <div className={`p-3 rounded-lg border ${isDark ? 'border-gray-600 bg-gray-700' : 'border-gray-200 bg-gray-50'}`}>
-                <input
-                  type="text"
-                  placeholder="Nome do local"
-                  value={newLocation.name}
-                  onChange={(e) => setNewLocation({ ...newLocation, name: e.target.value })}
-                  className={`w-full p-2 mb-2 border rounded ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
-                />
-                <input
-                  type="text"
-                  placeholder="Tipo (cidade, floresta, castelo...)"
-                  value={newLocation.type}
-                  onChange={(e) => setNewLocation({ ...newLocation, type: e.target.value })}
-                  className={`w-full p-2 mb-2 border rounded ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
-                />
-                <textarea
-                  placeholder="Descrição do local"
-                  value={newLocation.description}
-                  onChange={(e) => setNewLocation({ ...newLocation, description: e.target.value })}
-                  className={`w-full p-2 mb-2 border rounded h-20 ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
-                />
+                <div className="mb-2">
+                  <label htmlFor="location-name" className="block text-sm mb-1">Nome do local</label>
+                  <input
+                    id="location-name"
+                    type="text"
+                    value={newLocation.name}
+                    onChange={(e) => {
+                      setNewLocation({ ...newLocation, name: e.target.value });
+                      if (locationErrors.name) setLocationErrors({ ...locationErrors, name: '' });
+                    }}
+                    className={`w-full p-2 border rounded ${locationErrors.name ? 'border-red-500' : isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
+                  />
+                  {locationErrors.name && <p className="text-red-500 text-sm mt-1">{locationErrors.name}</p>}
+                </div>
+                <div className="mb-2">
+                  <label htmlFor="location-type" className="block text-sm mb-1">Tipo</label>
+                  <input
+                    id="location-type"
+                    type="text"
+                    value={newLocation.type}
+                    onChange={(e) => {
+                      setNewLocation({ ...newLocation, type: e.target.value });
+                      if (locationErrors.type) setLocationErrors({ ...locationErrors, type: '' });
+                    }}
+                    className={`w-full p-2 border rounded ${locationErrors.type ? 'border-red-500' : isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
+                  />
+                  {locationErrors.type && <p className="text-red-500 text-sm mt-1">{locationErrors.type}</p>}
+                </div>
+                <div className="mb-2">
+                  <label htmlFor="location-description" className="block text-sm mb-1">Descrição do local</label>
+                  <textarea
+                    id="location-description"
+                    value={newLocation.description}
+                    onChange={(e) => {
+                      setNewLocation({ ...newLocation, description: e.target.value });
+                      if (locationErrors.description) setLocationErrors({ ...locationErrors, description: '' });
+                    }}
+                    className={`w-full p-2 border rounded h-20 ${locationErrors.description ? 'border-red-500' : isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
+                  />
+                  {locationErrors.description && <p className="text-red-500 text-sm mt-1">{locationErrors.description}</p>}
+                </div>
                 <button
-                  onClick={addLocation}
+                  onClick={handleAddLocation}
                   className="w-full bg-purple-600 text-white p-2 rounded hover:bg-purple-700"
                 >
                   Adicionar
@@ -245,7 +312,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             )}
 
             <div className="space-y-3">
-              {locations.map(loc => (
+              {locations.map((loc: any) => (
                 <div key={loc.id} className={`p-3 rounded-lg border ${isDark ? 'border-gray-600 bg-gray-700' : 'border-gray-200 bg-gray-50'}`}>
                   <div className="flex justify-between items-start">
                     <div className="flex-1">
@@ -280,28 +347,49 @@ const Sidebar: React.FC<SidebarProps> = ({
 
             {showPlotForm && (
               <div className={`p-3 rounded-lg border ${isDark ? 'border-gray-600 bg-gray-700' : 'border-gray-200 bg-gray-50'}`}>
-                <input
-                  type="text"
-                  placeholder="Título do evento"
-                  value={newPlotPoint.title}
-                  onChange={(e) => setNewPlotPoint({ ...newPlotPoint, title: e.target.value })}
-                  className={`w-full p-2 mb-2 border rounded ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
-                />
-                <input
-                  type="text"
-                  placeholder="Capítulo/Seção"
-                  value={newPlotPoint.chapter}
-                  onChange={(e) => setNewPlotPoint({ ...newPlotPoint, chapter: e.target.value })}
-                  className={`w-full p-2 mb-2 border rounded ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
-                />
-                <textarea
-                  placeholder="Descrição do evento"
-                  value={newPlotPoint.description}
-                  onChange={(e) => setNewPlotPoint({ ...newPlotPoint, description: e.target.value })}
-                  className={`w-full p-2 mb-2 border rounded h-20 ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
-                />
+                <div className="mb-2">
+                  <label htmlFor="plot-title" className="block text-sm mb-1">Título do evento</label>
+                  <input
+                    id="plot-title"
+                    type="text"
+                    value={newPlotPoint.title}
+                    onChange={(e) => {
+                      setNewPlotPoint({ ...newPlotPoint, title: e.target.value });
+                      if (plotErrors.title) setPlotErrors({ ...plotErrors, title: '' });
+                    }}
+                    className={`w-full p-2 border rounded ${plotErrors.title ? 'border-red-500' : isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
+                  />
+                  {plotErrors.title && <p className="text-red-500 text-sm mt-1">{plotErrors.title}</p>}
+                </div>
+                <div className="mb-2">
+                  <label htmlFor="plot-chapter" className="block text-sm mb-1">Capítulo/Seção</label>
+                  <input
+                    id="plot-chapter"
+                    type="text"
+                    value={newPlotPoint.chapter}
+                    onChange={(e) => {
+                      setNewPlotPoint({ ...newPlotPoint, chapter: e.target.value });
+                      if (plotErrors.chapter) setPlotErrors({ ...plotErrors, chapter: '' });
+                    }}
+                    className={`w-full p-2 border rounded ${plotErrors.chapter ? 'border-red-500' : isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
+                  />
+                  {plotErrors.chapter && <p className="text-red-500 text-sm mt-1">{plotErrors.chapter}</p>}
+                </div>
+                <div className="mb-2">
+                  <label htmlFor="plot-description" className="block text-sm mb-1">Descrição do evento</label>
+                  <textarea
+                    id="plot-description"
+                    value={newPlotPoint.description}
+                    onChange={(e) => {
+                      setNewPlotPoint({ ...newPlotPoint, description: e.target.value });
+                      if (plotErrors.description) setPlotErrors({ ...plotErrors, description: '' });
+                    }}
+                    className={`w-full p-2 border rounded h-20 ${plotErrors.description ? 'border-red-500' : isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
+                  />
+                  {plotErrors.description && <p className="text-red-500 text-sm mt-1">{plotErrors.description}</p>}
+                </div>
                 <button
-                  onClick={addPlotPoint}
+                  onClick={handleAddPlotPoint}
                   className="w-full bg-purple-600 text-white p-2 rounded hover:bg-purple-700"
                 >
                   Adicionar
@@ -310,7 +398,7 @@ const Sidebar: React.FC<SidebarProps> = ({
             )}
 
             <div className="space-y-3">
-              {plotPoints.map(plot => (
+              {plotPoints.map((plot: any) => (
                 <div key={plot.id} className={`p-3 rounded-lg border ${isDark ? 'border-gray-600 bg-gray-700' : 'border-gray-200 bg-gray-50'}`}>
                   <div className="flex justify-between items-start">
                     <div className="flex-1">
@@ -341,31 +429,49 @@ const Sidebar: React.FC<SidebarProps> = ({
 
             {showSubplotForm && (
               <div className={`p-3 rounded-lg border ${isDark ? 'border-gray-600 bg-gray-700' : 'border-gray-200 bg-gray-50'}`}>
-                <input
-                  type="text"
-                  placeholder="Título do subplot"
-                  value={newSubplot.title}
-                  onChange={(e) => setNewSubplot({ ...newSubplot, title: e.target.value })}
-                  className={`w-full p-2 mb-2 border rounded ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
-                />
-                <select
-                  value={newSubplot.parent}
-                  onChange={(e) => setNewSubplot({ ...newSubplot, parent: e.target.value })}
-                  className={`w-full p-2 mb-2 border rounded ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
-                >
-                  <option value="">Plot principal</option>
-                  {plotPoints.map(p => (
-                    <option key={p.id} value={p.id}>{p.title}</option>
-                  ))}
-                </select>
-                <textarea
-                  placeholder="Descrição do subplot"
-                  value={newSubplot.description}
-                  onChange={(e) => setNewSubplot({ ...newSubplot, description: e.target.value })}
-                  className={`w-full p-2 mb-2 border rounded h-20 ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
-                />
+                <div className="mb-2">
+                  <label htmlFor="subplot-title" className="block text-sm mb-1">Título do subplot</label>
+                  <input
+                    id="subplot-title"
+                    type="text"
+                    value={newSubplot.title}
+                    onChange={(e) => {
+                      setNewSubplot({ ...newSubplot, title: e.target.value });
+                      if (subplotErrors.title) setSubplotErrors({ ...subplotErrors, title: '' });
+                    }}
+                    className={`w-full p-2 border rounded ${subplotErrors.title ? 'border-red-500' : isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
+                  />
+                  {subplotErrors.title && <p className="text-red-500 text-sm mt-1">{subplotErrors.title}</p>}
+                </div>
+                <div className="mb-2">
+                  <label htmlFor="subplot-parent" className="block text-sm mb-1">Plot pai</label>
+                  <select
+                    id="subplot-parent"
+                    value={newSubplot.parent}
+                    onChange={(e) => setNewSubplot({ ...newSubplot, parent: e.target.value })}
+                    className={`w-full p-2 border rounded ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
+                  >
+                    <option value="">Plot principal</option>
+                    {plotPoints.map((p: any) => (
+                      <option key={p.id} value={p.id}>{p.title}</option>
+                    ))}
+                  </select>
+                </div>
+                <div className="mb-2">
+                  <label htmlFor="subplot-description" className="block text-sm mb-1">Descrição do subplot</label>
+                  <textarea
+                    id="subplot-description"
+                    value={newSubplot.description}
+                    onChange={(e) => {
+                      setNewSubplot({ ...newSubplot, description: e.target.value });
+                      if (subplotErrors.description) setSubplotErrors({ ...subplotErrors, description: '' });
+                    }}
+                    className={`w-full p-2 border rounded h-20 ${subplotErrors.description ? 'border-red-500' : isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
+                  />
+                  {subplotErrors.description && <p className="text-red-500 text-sm mt-1">{subplotErrors.description}</p>}
+                </div>
                 <button
-                  onClick={addSubplot}
+                  onClick={handleAddSubplot}
                   className="w-full bg-purple-600 text-white p-2 rounded hover:bg-purple-700"
                 >
                   Adicionar
@@ -374,12 +480,12 @@ const Sidebar: React.FC<SidebarProps> = ({
             )}
 
             <div className="space-y-3">
-              {subplots.map(sp => (
+              {subplots.map((sp: any) => (
                 <div key={sp.id} className={`p-3 rounded-lg border ${isDark ? 'border-gray-600 bg-gray-700' : 'border-gray-200 bg-gray-50'}`}>
                   <div className="flex justify-between items-start">
                     <div className="flex-1">
                       <h4 className="font-medium">{sp.title}</h4>
-                      {sp.parent && <p className="text-sm text-purple-600">Plot: {plotPoints.find(p => p.id === sp.parent)?.title}</p>}
+                      {sp.parent && <p className="text-sm text-purple-600">Plot: {plotPoints.find((p: any) => p.id === sp.parent)?.title}</p>}
                       {sp.description && <p className={`text-sm mt-1 ${isDark ? 'text-gray-300' : 'text-gray-600'}`}>{sp.description}</p>}
                     </div>
                     <button
@@ -409,28 +515,44 @@ const Sidebar: React.FC<SidebarProps> = ({
 
             {showRelationForm && (
               <div className={`p-3 rounded-lg border ${isDark ? 'border-gray-600 bg-gray-700' : 'border-gray-200 bg-gray-50'}`}>
-                <select
-                  value={newRelation.characterId}
-                  onChange={(e) => setNewRelation({ ...newRelation, characterId: e.target.value })}
-                  className={`w-full p-2 mb-2 border rounded ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
-                >
-                  <option value="">Personagem</option>
-                  {characters.map(c => (
-                    <option key={c.id} value={c.id}>{c.name}</option>
-                  ))}
-                </select>
-                <select
-                  value={newRelation.locationId}
-                  onChange={(e) => setNewRelation({ ...newRelation, locationId: e.target.value })}
-                  className={`w-full p-2 mb-2 border rounded ${isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
-                >
-                  <option value="">Local</option>
-                  {locations.map(l => (
-                    <option key={l.id} value={l.id}>{l.name}</option>
-                  ))}
-                </select>
+                <div className="mb-2">
+                  <label htmlFor="relation-character" className="block text-sm mb-1">Personagem</label>
+                  <select
+                    id="relation-character"
+                    value={newRelation.characterId}
+                    onChange={(e) => {
+                      setNewRelation({ ...newRelation, characterId: e.target.value });
+                      if (relationErrors.characterId) setRelationErrors({ ...relationErrors, characterId: '' });
+                    }}
+                    className={`w-full p-2 border rounded ${relationErrors.characterId ? 'border-red-500' : isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
+                  >
+                    <option value="">Personagem</option>
+                    {characters.map((c: any) => (
+                      <option key={c.id} value={c.id}>{c.name}</option>
+                    ))}
+                  </select>
+                  {relationErrors.characterId && <p className="text-red-500 text-sm mt-1">{relationErrors.characterId}</p>}
+                </div>
+                <div className="mb-2">
+                  <label htmlFor="relation-location" className="block text-sm mb-1">Local</label>
+                  <select
+                    id="relation-location"
+                    value={newRelation.locationId}
+                    onChange={(e) => {
+                      setNewRelation({ ...newRelation, locationId: e.target.value });
+                      if (relationErrors.locationId) setRelationErrors({ ...relationErrors, locationId: '' });
+                    }}
+                    className={`w-full p-2 border rounded ${relationErrors.locationId ? 'border-red-500' : isDark ? 'bg-gray-600 border-gray-500 text-gray-100' : 'bg-white border-gray-300'}`}
+                  >
+                    <option value="">Local</option>
+                    {locations.map((l: any) => (
+                      <option key={l.id} value={l.id}>{l.name}</option>
+                    ))}
+                  </select>
+                  {relationErrors.locationId && <p className="text-red-500 text-sm mt-1">{relationErrors.locationId}</p>}
+                </div>
                 <button
-                  onClick={addRelation}
+                  onClick={handleAddRelation}
                   className="w-full bg-purple-600 text-white p-2 rounded hover:bg-purple-700"
                 >
                   Integrar
@@ -439,9 +561,9 @@ const Sidebar: React.FC<SidebarProps> = ({
             )}
 
             <div className="space-y-3">
-              {charLocations.map(rel => {
-                const char = characters.find(c => c.id === rel.characterId);
-                const loc = locations.find(l => l.id === rel.locationId);
+              {charLocations.map((rel: any) => {
+                const char = characters.find((c: any) => c.id === rel.characterId);
+                const loc = locations.find((l: any) => l.id === rel.locationId);
                 return (
                   <div key={rel.id} className={`p-3 rounded-lg border ${isDark ? 'border-gray-600 bg-gray-700' : 'border-gray-200 bg-gray-50'}`}>
                     <div className="flex justify-between items-start">

--- a/src/universe/CharacterForm.tsx
+++ b/src/universe/CharacterForm.tsx
@@ -19,9 +19,13 @@ const CharacterForm = ({ character, onSave, onCancel }: CharacterFormProps) => {
     relationships: '',
     role: ''
   });
+  const [errors, setErrors] = useState({ name: '' });
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    const newErrors = { name: formData.name.trim() ? '' : 'Nome é obrigatório' };
+    setErrors(newErrors);
+    if (Object.values(newErrors).some(Boolean)) return;
     onSave({ ...formData, id: character?.id || Date.now() });
   };
 
@@ -33,59 +37,86 @@ const CharacterForm = ({ character, onSave, onCancel }: CharacterFormProps) => {
         </h3>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="grid grid-cols-2 gap-4">
-            <input
-              type="text"
-              placeholder="Nome"
-              value={formData.name}
-              onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-              className="border rounded px-3 py-2"
-              required
-            />
-            <input
-              type="number"
-              placeholder="Idade"
-              value={formData.age}
-              onChange={(e) => setFormData({ ...formData, age: e.target.value })}
-              className="border rounded px-3 py-2"
+            <div className="flex flex-col">
+              <label htmlFor="char-name" className="mb-1 text-sm">Nome</label>
+              <input
+                id="char-name"
+                type="text"
+                value={formData.name}
+                onChange={(e) => {
+                  setFormData({ ...formData, name: e.target.value });
+                  if (errors.name) setErrors({ name: '' });
+                }}
+                className={`border rounded px-3 py-2 ${errors.name ? 'border-red-500' : ''}`}
+              />
+              {errors.name && <span className="text-red-500 text-sm mt-1">{errors.name}</span>}
+            </div>
+            <div className="flex flex-col">
+              <label htmlFor="char-age" className="mb-1 text-sm">Idade</label>
+              <input
+                id="char-age"
+                type="number"
+                value={formData.age}
+                onChange={(e) => setFormData({ ...formData, age: e.target.value })}
+                className="border rounded px-3 py-2"
+              />
+            </div>
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="char-appearance" className="mb-1 text-sm">Aparência</label>
+            <textarea
+              id="char-appearance"
+              value={formData.appearance}
+              onChange={(e) => setFormData({ ...formData, appearance: e.target.value })}
+              className="border rounded px-3 py-2 w-full h-20"
             />
           </div>
-          <textarea
-            placeholder="Aparência"
-            value={formData.appearance}
-            onChange={(e) => setFormData({ ...formData, appearance: e.target.value })}
-            className="border rounded px-3 py-2 w-full h-20"
-          />
-          <textarea
-            placeholder="Histórico"
-            value={formData.background}
-            onChange={(e) => setFormData({ ...formData, background: e.target.value })}
-            className="border rounded px-3 py-2 w-full h-24"
-          />
-          <textarea
-            placeholder="Habilidades"
-            value={formData.abilities}
-            onChange={(e) => setFormData({ ...formData, abilities: e.target.value })}
-            className="border rounded px-3 py-2 w-full h-20"
-          />
-          <textarea
-            placeholder="Motivações"
-            value={formData.motivations}
-            onChange={(e) => setFormData({ ...formData, motivations: e.target.value })}
-            className="border rounded px-3 py-2 w-full h-20"
-          />
-          <textarea
-            placeholder="Relacionamentos"
-            value={formData.relationships}
-            onChange={(e) => setFormData({ ...formData, relationships: e.target.value })}
-            className="border rounded px-3 py-2 w-full h-20"
-          />
-          <input
-            type="text"
-            placeholder="Papel Narrativo"
-            value={formData.role}
-            onChange={(e) => setFormData({ ...formData, role: e.target.value })}
-            className="border rounded px-3 py-2 w-full"
-          />
+          <div className="flex flex-col">
+            <label htmlFor="char-background" className="mb-1 text-sm">Histórico</label>
+            <textarea
+              id="char-background"
+              value={formData.background}
+              onChange={(e) => setFormData({ ...formData, background: e.target.value })}
+              className="border rounded px-3 py-2 w-full h-24"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="char-abilities" className="mb-1 text-sm">Habilidades</label>
+            <textarea
+              id="char-abilities"
+              value={formData.abilities}
+              onChange={(e) => setFormData({ ...formData, abilities: e.target.value })}
+              className="border rounded px-3 py-2 w-full h-20"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="char-motivations" className="mb-1 text-sm">Motivações</label>
+            <textarea
+              id="char-motivations"
+              value={formData.motivations}
+              onChange={(e) => setFormData({ ...formData, motivations: e.target.value })}
+              className="border rounded px-3 py-2 w-full h-20"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="char-relationships" className="mb-1 text-sm">Relacionamentos</label>
+            <textarea
+              id="char-relationships"
+              value={formData.relationships}
+              onChange={(e) => setFormData({ ...formData, relationships: e.target.value })}
+              className="border rounded px-3 py-2 w-full h-20"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="char-role" className="mb-1 text-sm">Papel Narrativo</label>
+            <input
+              id="char-role"
+              type="text"
+              value={formData.role}
+              onChange={(e) => setFormData({ ...formData, role: e.target.value })}
+              className="border rounded px-3 py-2 w-full"
+            />
+          </div>
           <div className="flex gap-2 pt-4">
             <button
               type="submit"

--- a/src/universe/EconomyForm.tsx
+++ b/src/universe/EconomyForm.tsx
@@ -17,9 +17,13 @@ const EconomyForm = ({ economy, onSave, onCancel }: EconomyFormProps) => {
       mainExports: ''
     }
   );
+  const [errors, setErrors] = useState({ name: '' });
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    const newErrors = { name: formData.name.trim() ? '' : 'Nome é obrigatório' };
+    setErrors(newErrors);
+    if (Object.values(newErrors).some(Boolean)) return;
     onSave({ ...formData, id: economy?.id || Date.now() });
   };
 
@@ -30,35 +34,50 @@ const EconomyForm = ({ economy, onSave, onCancel }: EconomyFormProps) => {
           {economy ? 'Editar Economia' : 'Nova Economia'}
         </h3>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="text"
-            placeholder="Nome"
-            value={formData.name}
-            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-            className="border rounded px-3 py-2 w-full"
-            required
-          />
-          <input
-            type="text"
-            placeholder="Moeda"
-            value={formData.currency}
-            onChange={(e) => setFormData({ ...formData, currency: e.target.value })}
-            className="border rounded px-3 py-2 w-full"
-          />
-          <input
-            type="text"
-            placeholder="Mercados principais"
-            value={formData.markets}
-            onChange={(e) => setFormData({ ...formData, markets: e.target.value })}
-            className="border rounded px-3 py-2 w-full"
-          />
-          <input
-            type="text"
-            placeholder="Exportações"
-            value={formData.mainExports}
-            onChange={(e) => setFormData({ ...formData, mainExports: e.target.value })}
-            className="border rounded px-3 py-2 w-full"
-          />
+          <div className="flex flex-col">
+            <label htmlFor="economy-name" className="mb-1 text-sm">Nome</label>
+            <input
+              id="economy-name"
+              type="text"
+              value={formData.name}
+              onChange={(e) => {
+                setFormData({ ...formData, name: e.target.value });
+                if (errors.name) setErrors({ name: '' });
+              }}
+              className={`border rounded px-3 py-2 w-full ${errors.name ? 'border-red-500' : ''}`}
+            />
+            {errors.name && <span className="text-red-500 text-sm mt-1">{errors.name}</span>}
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="economy-currency" className="mb-1 text-sm">Moeda</label>
+            <input
+              id="economy-currency"
+              type="text"
+              value={formData.currency}
+              onChange={(e) => setFormData({ ...formData, currency: e.target.value })}
+              className="border rounded px-3 py-2 w-full"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="economy-markets" className="mb-1 text-sm">Mercados principais</label>
+            <input
+              id="economy-markets"
+              type="text"
+              value={formData.markets}
+              onChange={(e) => setFormData({ ...formData, markets: e.target.value })}
+              className="border rounded px-3 py-2 w-full"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="economy-exports" className="mb-1 text-sm">Exportações</label>
+            <input
+              id="economy-exports"
+              type="text"
+              value={formData.mainExports}
+              onChange={(e) => setFormData({ ...formData, mainExports: e.target.value })}
+              className="border rounded px-3 py-2 w-full"
+            />
+          </div>
           <div className="flex gap-2 pt-4">
             <button
               type="submit"

--- a/src/universe/LanguageForm.tsx
+++ b/src/universe/LanguageForm.tsx
@@ -18,6 +18,7 @@ const LanguageForm = ({ language, onSave, onCancel }: LanguageFormProps) => {
     }
   );
   const [generatedName, setGeneratedName] = useState('');
+  const [errors, setErrors] = useState({ name: '' });
 
   const generateName = () => {
     const syllables = formData.syllables
@@ -35,6 +36,9 @@ const LanguageForm = ({ language, onSave, onCancel }: LanguageFormProps) => {
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    const newErrors = { name: formData.name.trim() ? '' : 'Nome é obrigatório' };
+    setErrors(newErrors);
+    if (Object.values(newErrors).some(Boolean)) return;
     onSave({ ...formData, id: language?.id || Date.now() });
   };
 
@@ -45,33 +49,49 @@ const LanguageForm = ({ language, onSave, onCancel }: LanguageFormProps) => {
           {language ? 'Editar Língua' : 'Nova Língua'}
         </h3>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="text"
-            placeholder="Nome"
-            value={formData.name}
-            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-            className="border rounded px-3 py-2 w-full"
-            required
-          />
-          <textarea
-            placeholder="Vocabulário (palavra:tradução por linha)"
-            value={formData.vocabulary}
-            onChange={(e) => setFormData({ ...formData, vocabulary: e.target.value })}
-            className="border rounded px-3 py-2 w-full h-24"
-          />
-          <textarea
-            placeholder="Regras gramaticais"
-            value={formData.grammar}
-            onChange={(e) => setFormData({ ...formData, grammar: e.target.value })}
-            className="border rounded px-3 py-2 w-full h-24"
-          />
-          <input
-            type="text"
-            placeholder="Sílabas para gerador (separadas por vírgula)"
-            value={formData.syllables}
-            onChange={(e) => setFormData({ ...formData, syllables: e.target.value })}
-            className="border rounded px-3 py-2 w-full"
-          />
+          <div className="flex flex-col">
+            <label htmlFor="language-name" className="mb-1 text-sm">Nome</label>
+            <input
+              id="language-name"
+              type="text"
+              value={formData.name}
+              onChange={(e) => {
+                setFormData({ ...formData, name: e.target.value });
+                if (errors.name) setErrors({ name: '' });
+              }}
+              className={`border rounded px-3 py-2 w-full ${errors.name ? 'border-red-500' : ''}`}
+            />
+            {errors.name && <span className="text-red-500 text-sm mt-1">{errors.name}</span>}
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="language-vocab" className="mb-1 text-sm">Vocabulário (palavra:tradução por linha)</label>
+            <textarea
+              id="language-vocab"
+              value={formData.vocabulary}
+              onChange={(e) => setFormData({ ...formData, vocabulary: e.target.value })}
+              className="border rounded px-3 py-2 w-full h-24"
+            />
+          </div>
+  
+          <div className="flex flex-col">
+            <label htmlFor="language-grammar" className="mb-1 text-sm">Regras gramaticais</label>
+            <textarea
+              id="language-grammar"
+              value={formData.grammar}
+              onChange={(e) => setFormData({ ...formData, grammar: e.target.value })}
+              className="border rounded px-3 py-2 w-full h-24"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="language-syllables" className="mb-1 text-sm">Sílabas para gerador (separadas por vírgula)</label>
+            <input
+              id="language-syllables"
+              type="text"
+              value={formData.syllables}
+              onChange={(e) => setFormData({ ...formData, syllables: e.target.value })}
+              className="border rounded px-3 py-2 w-full"
+            />
+          </div>
           {generatedName && (
             <p className="text-sm">Nome gerado: <span className="font-semibold">{generatedName}</span></p>
           )}

--- a/src/universe/LocationForm.tsx
+++ b/src/universe/LocationForm.tsx
@@ -33,9 +33,13 @@ const LocationForm = ({ location, onSave, onCancel, generatePopulation, generate
     battles: '',
     events: ''
   });
+  const [errors, setErrors] = useState({ name: '' });
 
-    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    const newErrors = { name: formData.name.trim() ? '' : 'Nome é obrigatório' };
+    setErrors(newErrors);
+    if (Object.values(newErrors).some(Boolean)) return;
     onSave({ ...formData, id: location?.id || Date.now() });
   };
 
@@ -54,16 +58,25 @@ const LocationForm = ({ location, onSave, onCancel, generatePopulation, generate
           {/* Informações Básicas */}
           <div className="border-b pb-4">
             <h4 className="font-semibold mb-3">Informações Básicas</h4>
-            <div className="grid grid-cols-3 gap-4">
+          <div className="grid grid-cols-3 gap-4">
+            <div className="flex flex-col">
+              <label htmlFor="loc-name" className="mb-1 text-sm">Nome</label>
               <input
+                id="loc-name"
                 type="text"
-                placeholder="Nome"
                 value={formData.name}
-                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                className="border rounded px-3 py-2"
-                required
+                onChange={(e) => {
+                  setFormData({ ...formData, name: e.target.value });
+                  if (errors.name) setErrors({ name: '' });
+                }}
+                className={`border rounded px-3 py-2 ${errors.name ? 'border-red-500' : ''}`}
               />
+              {errors.name && <span className="text-red-500 text-sm mt-1">{errors.name}</span>}
+            </div>
+            <div className="flex flex-col">
+              <label htmlFor="loc-type" className="mb-1 text-sm">Tipo</label>
               <select
+                id="loc-type"
                 value={formData.type}
                 onChange={(e) => setFormData({ ...formData, type: e.target.value })}
                 className="border rounded px-3 py-2"
@@ -73,98 +86,126 @@ const LocationForm = ({ location, onSave, onCancel, generatePopulation, generate
                 <option value="reino">Reino</option>
                 <option value="fortaleza">Fortaleza</option>
               </select>
+            </div>
+            <div className="flex flex-col">
+              <label htmlFor="loc-climate" className="mb-1 text-sm">Clima</label>
               <input
+                id="loc-climate"
                 type="text"
-                placeholder="Clima"
                 value={formData.climate}
                 onChange={(e) => setFormData({ ...formData, climate: e.target.value })}
                 className="border rounded px-3 py-2"
               />
             </div>
           </div>
+          </div>
 
           {/* População */}
           <div className="border-b pb-4">
             <h4 className="font-semibold mb-3">População</h4>
-            <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="flex flex-col">
+              <label htmlFor="loc-population" className="mb-1 text-sm">Número de habitantes</label>
               <input
+                id="loc-population"
                 type="number"
-                placeholder="Número de habitantes"
                 value={formData.population}
                 onChange={(e) => setFormData({ ...formData, population: parseInt(e.target.value) })}
                 className="border rounded px-3 py-2"
               />
+            </div>
+            <div className="flex flex-col">
+              <label htmlFor="loc-culture" className="mb-1 text-sm">Composição cultural/étnica</label>
               <input
+                id="loc-culture"
                 type="text"
-                placeholder="Composição cultural/étnica"
                 value={formData.culturalComposition}
                 onChange={(e) => setFormData({ ...formData, culturalComposition: e.target.value })}
                 className="border rounded px-3 py-2"
               />
             </div>
           </div>
+          </div>
 
           {/* Economia e Profissões */}
           <div className="border-b pb-4">
             <h4 className="font-semibold mb-3">Economia</h4>
             <div className="grid grid-cols-2 gap-4">
-              <input
-                type="text"
-                placeholder="Setor econômico principal"
-                value={formData.economy}
-                onChange={(e) => setFormData({ ...formData, economy: e.target.value })}
-                className="border rounded px-3 py-2"
-              />
-              <input
-                type="text"
-                placeholder="Profissões (separadas por vírgula)"
-                value={formData.mainProfessions.join(', ')}
-                onChange={(e) => handleArrayChange('mainProfessions', e.target.value)}
-                className="border rounded px-3 py-2"
+              <div className="flex flex-col">
+                <label htmlFor="loc-economy" className="mb-1 text-sm">Setor econômico principal</label>
+                <input
+                  id="loc-economy"
+                  type="text"
+                  value={formData.economy}
+                  onChange={(e) => setFormData({ ...formData, economy: e.target.value })}
+                  className="border rounded px-3 py-2"
+                />
+              </div>
+              <div className="flex flex-col">
+                <label htmlFor="loc-professions" className="mb-1 text-sm">Profissões (separadas por vírgula)</label>
+                <input
+                  id="loc-professions"
+                  type="text"
+                  value={formData.mainProfessions.join(', ')}
+                  onChange={(e) => handleArrayChange('mainProfessions', e.target.value)}
+                  className="border rounded px-3 py-2"
+                />
+              </div>
+            </div>
+            <div className="flex flex-col mt-2">
+              <label htmlFor="loc-resources" className="mb-1 text-sm">Recursos e fontes de riqueza</label>
+              <textarea
+                id="loc-resources"
+                value={formData.resources}
+                onChange={(e) => setFormData({ ...formData, resources: e.target.value })}
+                className="border rounded px-3 py-2 w-full h-20"
               />
             </div>
-            <textarea
-              placeholder="Recursos e fontes de riqueza"
-              value={formData.resources}
-              onChange={(e) => setFormData({ ...formData, resources: e.target.value })}
-              className="border rounded px-3 py-2 w-full h-20 mt-2"
-            />
           </div>
 
           {/* Exército */}
           <div className="border-b pb-4">
             <h4 className="font-semibold mb-3">Exército Local</h4>
             <div className="grid grid-cols-3 gap-4">
-              <input
-                type="number"
-                placeholder="Tamanho do exército"
-                value={formData.army.size}
-                onChange={(e) => setFormData({
-                  ...formData,
-                  army: { ...formData.army, size: parseInt(e.target.value) }
-                })}
-                className="border rounded px-3 py-2"
-              />
-              <input
-                type="text"
-                placeholder="Armas principais"
-                value={formData.army.weapons}
-                onChange={(e) => setFormData({
-                  ...formData,
-                  army: { ...formData.army, weapons: e.target.value }
-                })}
-                className="border rounded px-3 py-2"
-              />
-              <input
-                type="text"
-                placeholder="Nível de treinamento"
-                value={formData.army.training}
-                onChange={(e) => setFormData({
-                  ...formData,
-                  army: { ...formData.army, training: e.target.value }
-                })}
-                className="border rounded px-3 py-2"
-              />
+              <div className="flex flex-col">
+                <label htmlFor="loc-army-size" className="mb-1 text-sm">Tamanho do exército</label>
+                <input
+                  id="loc-army-size"
+                  type="number"
+                  value={formData.army.size}
+                  onChange={(e) => setFormData({
+                    ...formData,
+                    army: { ...formData.army, size: parseInt(e.target.value) }
+                  })}
+                  className="border rounded px-3 py-2"
+                />
+              </div>
+              <div className="flex flex-col">
+                <label htmlFor="loc-army-weapons" className="mb-1 text-sm">Armas principais</label>
+                <input
+                  id="loc-army-weapons"
+                  type="text"
+                  value={formData.army.weapons}
+                  onChange={(e) => setFormData({
+                    ...formData,
+                    army: { ...formData.army, weapons: e.target.value }
+                  })}
+                  className="border rounded px-3 py-2"
+                />
+              </div>
+              <div className="flex flex-col">
+                <label htmlFor="loc-army-training" className="mb-1 text-sm">Nível de treinamento</label>
+                <input
+                  id="loc-army-training"
+                  type="text"
+                  value={formData.army.training}
+                  onChange={(e) => setFormData({
+                    ...formData,
+                    army: { ...formData.army, training: e.target.value }
+                  })}
+                  className="border rounded px-3 py-2"
+                />
+              </div>
             </div>
           </div>
 
@@ -172,20 +213,26 @@ const LocationForm = ({ location, onSave, onCancel, generatePopulation, generate
           <div className="border-b pb-4">
             <h4 className="font-semibold mb-3">Religião e Cultura</h4>
             <div className="grid grid-cols-2 gap-4">
-              <input
-                type="text"
-                placeholder="Religiões aceitas (separadas por vírgula)"
-                value={formData.religions.join(', ')}
-                onChange={(e) => handleArrayChange('religions', e.target.value)}
-                className="border rounded px-3 py-2"
-              />
-              <input
-                type="text"
-                placeholder="Alimentos comuns (separados por vírgula)"
-                value={formData.commonFoods.join(', ')}
-                onChange={(e) => handleArrayChange('commonFoods', e.target.value)}
-                className="border rounded px-3 py-2"
-              />
+              <div className="flex flex-col">
+                <label htmlFor="loc-religions" className="mb-1 text-sm">Religiões aceitas (separadas por vírgula)</label>
+                <input
+                  id="loc-religions"
+                  type="text"
+                  value={formData.religions.join(', ')}
+                  onChange={(e) => handleArrayChange('religions', e.target.value)}
+                  className="border rounded px-3 py-2"
+                />
+              </div>
+              <div className="flex flex-col">
+                <label htmlFor="loc-foods" className="mb-1 text-sm">Alimentos comuns (separados por vírgula)</label>
+                <input
+                  id="loc-foods"
+                  type="text"
+                  value={formData.commonFoods.join(', ')}
+                  onChange={(e) => handleArrayChange('commonFoods', e.target.value)}
+                  className="border rounded px-3 py-2"
+                />
+              </div>
             </div>
           </div>
 
@@ -193,18 +240,26 @@ const LocationForm = ({ location, onSave, onCancel, generatePopulation, generate
           <div className="border-b pb-4">
             <h4 className="font-semibold mb-3">Infraestrutura</h4>
             <div className="grid grid-cols-2 gap-4">
-              <textarea
-                placeholder="Estabelecimentos comerciais"
-                value={formData.establishments}
-                onChange={(e) => setFormData({ ...formData, establishments: e.target.value })}
-                className="border rounded px-3 py-2 h-24"
-              />
-              <textarea
-                placeholder="Pontos estratégicos"
-                value={formData.strategicPoints}
-                onChange={(e) => setFormData({ ...formData, strategicPoints: e.target.value })}
-                className="border rounded px-3 py-2 h-24"
-              />
+              <div className="flex flex-col">
+                <label htmlFor="loc-establishments" className="mb-1 text-sm">Estabelecimentos comerciais</label>
+                <textarea
+                  id="loc-establishments"
+                  placeholder="Estabelecimentos comerciais"
+                  value={formData.establishments}
+                  onChange={(e) => setFormData({ ...formData, establishments: e.target.value })}
+                  className="border rounded px-3 py-2 h-24"
+                />
+              </div>
+              <div className="flex flex-col">
+                <label htmlFor="loc-strategic" className="mb-1 text-sm">Pontos estratégicos</label>
+                <textarea
+                  id="loc-strategic"
+                  placeholder="Pontos estratégicos"
+                  value={formData.strategicPoints}
+                  onChange={(e) => setFormData({ ...formData, strategicPoints: e.target.value })}
+                  className="border rounded px-3 py-2 h-24"
+                />
+              </div>
             </div>
           </div>
 
@@ -212,25 +267,37 @@ const LocationForm = ({ location, onSave, onCancel, generatePopulation, generate
           <div className="pb-4">
             <h4 className="font-semibold mb-3">História</h4>
             <div className="grid grid-cols-2 gap-4">
+              <div className="flex flex-col">
+                <label htmlFor="loc-government" className="mb-1 text-sm">Histórico de governos</label>
+                <textarea
+                  id="loc-government"
+                  placeholder="Histórico de governos"
+                  value={formData.government}
+                  onChange={(e) => setFormData({ ...formData, government: e.target.value })}
+                  className="border rounded px-3 py-2 h-24"
+                />
+              </div>
+              <div className="flex flex-col">
+                <label htmlFor="loc-battles" className="mb-1 text-sm">Batalhas importantes</label>
+                <textarea
+                  id="loc-battles"
+                  placeholder="Batalhas importantes"
+                  value={formData.battles}
+                  onChange={(e) => setFormData({ ...formData, battles: e.target.value })}
+                  className="border rounded px-3 py-2 h-24"
+                />
+              </div>
+            </div>
+            <div className="flex flex-col mt-2">
+              <label htmlFor="loc-events" className="mb-1 text-sm">Eventos importantes</label>
               <textarea
-                placeholder="Histórico de governos"
-                value={formData.government}
-                onChange={(e) => setFormData({ ...formData, government: e.target.value })}
-                className="border rounded px-3 py-2 h-24"
-              />
-              <textarea
-                placeholder="Batalhas importantes"
-                value={formData.battles}
-                onChange={(e) => setFormData({ ...formData, battles: e.target.value })}
-                className="border rounded px-3 py-2 h-24"
+                id="loc-events"
+                placeholder="Eventos importantes"
+                value={formData.events}
+                onChange={(e) => setFormData({ ...formData, events: e.target.value })}
+                className="border rounded px-3 py-2 w-full h-20"
               />
             </div>
-            <textarea
-              placeholder="Eventos importantes"
-              value={formData.events}
-              onChange={(e) => setFormData({ ...formData, events: e.target.value })}
-              className="border rounded px-3 py-2 w-full h-20 mt-2"
-            />
           </div>
 
           <div className="flex gap-2 pt-4">

--- a/src/universe/ReligionForm.tsx
+++ b/src/universe/ReligionForm.tsx
@@ -16,9 +16,13 @@ const ReligionForm = ({ religion, onSave, onCancel }: ReligionFormProps) => {
       factions: ''
     }
   );
+  const [errors, setErrors] = useState({ name: '' });
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    const newErrors = { name: formData.name.trim() ? '' : 'Nome é obrigatório' };
+    setErrors(newErrors);
+    if (Object.values(newErrors).some(Boolean)) return;
     onSave({ ...formData, id: religion?.id || Date.now() });
   };
 
@@ -29,27 +33,39 @@ const ReligionForm = ({ religion, onSave, onCancel }: ReligionFormProps) => {
           {religion ? 'Editar Religião' : 'Nova Religião'}
         </h3>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="text"
-            placeholder="Nome"
-            value={formData.name}
-            onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-            className="border rounded px-3 py-2 w-full"
-            required
-          />
-          <textarea
-            placeholder="Doutrina"
-            value={formData.doctrine}
-            onChange={(e) => setFormData({ ...formData, doctrine: e.target.value })}
-            className="border rounded px-3 py-2 w-full h-24"
-          />
-          <input
-            type="text"
-            placeholder="Facções (separadas por vírgula)"
-            value={formData.factions}
-            onChange={(e) => setFormData({ ...formData, factions: e.target.value })}
-            className="border rounded px-3 py-2 w-full"
-          />
+          <div className="flex flex-col">
+            <label htmlFor="religion-name" className="mb-1 text-sm">Nome</label>
+            <input
+              id="religion-name"
+              type="text"
+              value={formData.name}
+              onChange={(e) => {
+                setFormData({ ...formData, name: e.target.value });
+                if (errors.name) setErrors({ name: '' });
+              }}
+              className={`border rounded px-3 py-2 w-full ${errors.name ? 'border-red-500' : ''}`}
+            />
+            {errors.name && <span className="text-red-500 text-sm mt-1">{errors.name}</span>}
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="religion-doctrine" className="mb-1 text-sm">Doutrina</label>
+            <textarea
+              id="religion-doctrine"
+              value={formData.doctrine}
+              onChange={(e) => setFormData({ ...formData, doctrine: e.target.value })}
+              className="border rounded px-3 py-2 w-full h-24"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="religion-factions" className="mb-1 text-sm">Facções (separadas por vírgula)</label>
+            <input
+              id="religion-factions"
+              type="text"
+              value={formData.factions}
+              onChange={(e) => setFormData({ ...formData, factions: e.target.value })}
+              className="border rounded px-3 py-2 w-full"
+            />
+          </div>
           <div className="flex gap-2 pt-4">
             <button
               type="submit"

--- a/src/universe/TimelineForm.tsx
+++ b/src/universe/TimelineForm.tsx
@@ -17,9 +17,13 @@ const TimelineForm = ({ event, onSave, onCancel }: TimelineFormProps) => {
       relations: ''
     }
   );
+  const [errors, setErrors] = useState({ title: '' });
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+    const newErrors = { title: formData.title.trim() ? '' : 'Título é obrigatório' };
+    setErrors(newErrors);
+    if (Object.values(newErrors).some(Boolean)) return;
     onSave({ ...formData, id: event?.id || Date.now() });
   };
 
@@ -30,34 +34,49 @@ const TimelineForm = ({ event, onSave, onCancel }: TimelineFormProps) => {
           {event ? 'Editar Evento' : 'Novo Evento'}
         </h3>
         <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="text"
-            placeholder="Título"
-            value={formData.title}
-            onChange={(e) => setFormData({ ...formData, title: e.target.value })}
-            className="border rounded px-3 py-2 w-full"
-            required
-          />
-          <input
-            type="date"
-            placeholder="Data"
-            value={formData.date}
-            onChange={(e) => setFormData({ ...formData, date: e.target.value })}
-            className="border rounded px-3 py-2 w-full"
-          />
-          <textarea
-            placeholder="Descrição"
-            value={formData.description}
-            onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-            className="border rounded px-3 py-2 w-full h-24"
-          />
-          <input
-            type="text"
-            placeholder="Relacionamentos"
-            value={formData.relations}
-            onChange={(e) => setFormData({ ...formData, relations: e.target.value })}
-            className="border rounded px-3 py-2 w-full"
-          />
+          <div className="flex flex-col">
+            <label htmlFor="timeline-title" className="mb-1 text-sm">Título</label>
+            <input
+              id="timeline-title"
+              type="text"
+              value={formData.title}
+              onChange={(e) => {
+                setFormData({ ...formData, title: e.target.value });
+                if (errors.title) setErrors({ title: '' });
+              }}
+              className={`border rounded px-3 py-2 w-full ${errors.title ? 'border-red-500' : ''}`}
+            />
+            {errors.title && <span className="text-red-500 text-sm mt-1">{errors.title}</span>}
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="timeline-date" className="mb-1 text-sm">Data</label>
+            <input
+              id="timeline-date"
+              type="date"
+              value={formData.date}
+              onChange={(e) => setFormData({ ...formData, date: e.target.value })}
+              className="border rounded px-3 py-2 w-full"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="timeline-description" className="mb-1 text-sm">Descrição</label>
+            <textarea
+              id="timeline-description"
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              className="border rounded px-3 py-2 w-full h-24"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="timeline-relations" className="mb-1 text-sm">Relacionamentos</label>
+            <input
+              id="timeline-relations"
+              type="text"
+              value={formData.relations}
+              onChange={(e) => setFormData({ ...formData, relations: e.target.value })}
+              className="border rounded px-3 py-2 w-full"
+            />
+          </div>
           <div className="flex gap-2 pt-4">
             <button
               type="submit"


### PR DESCRIPTION
## Summary
- add labeled inputs with error messages to editor forms
- apply consistent labeling and validation to universe creation forms

## Testing
- `npm run build`
- `npm run typecheck` *(fails: Binding element 'setNewRelation' implicitly has an 'any' type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b591a50e848325a9c9d4432ea590c4