### PR TITLE
Add tooltips to UI buttons

### DIFF
--- a/src/editor.tsx
+++ b/src/editor.tsx
@@ -377,6 +377,8 @@ const FictionEditor = () => {
             <div className="flex items-center space-x-2 flex-wrap">
               <button
                 onClick={() => setIsSidebarOpen(!isSidebarOpen)}
+                title="Alternar barra lateral"
+                aria-label="Alternar barra lateral"
                 className={`md:hidden p-2 rounded-lg transition-colors ${isDark ? 'hover:bg-gray-700' : 'hover:bg-gray-200'}`}
               >
                 <Menu className="h-4 w-4" />

--- a/src/editor/Sidebar.tsx
+++ b/src/editor/Sidebar.tsx
@@ -149,6 +149,8 @@ const Sidebar: React.FC<SidebarProps> = ({
           <button
             key={tab.id}
             onClick={() => setActivePanel(tab.id)}
+            title={tab.label}
+            aria-label={tab.label}
             className={`flex-1 flex items-center justify-center p-3 text-sm font-medium border-b-2 transition-colors ${
               activePanel === tab.id
                 ? 'border-purple-500 text-purple-600'

--- a/src/ui/AppShell.tsx
+++ b/src/ui/AppShell.tsx
@@ -62,6 +62,8 @@ const AppShell: React.FC<AppShellProps> = ({
               <button
                 key={t.id}
                 onClick={() => onTabChange(t.id)}
+                title={t.label}
+                aria-label={t.label}
                 className={`w-full flex items-center gap-2 px-3 py-2 rounded-md text-left transition ${
                   activeTab === t.id
                     ? 'bg-[var(--primary)]/15 text-[var(--primary)]'

--- a/src/universeCreator.tsx
+++ b/src/universeCreator.tsx
@@ -94,6 +94,8 @@ const UniverseCreator = () => {
         <div className="flex gap-2">
           <button
             onClick={() => setSelectedCharacter(character)}
+            title="Editar personagem"
+            aria-label="Editar personagem"
             className="text-blue-500 hover:text-blue-700"
           >
             <Edit size={16} />
@@ -102,6 +104,8 @@ const UniverseCreator = () => {
             onClick={() => {
               removeCharacter(character.id);
             }}
+            title="Remover personagem"
+            aria-label="Remover personagem"
             className="text-red-500 hover:text-red-700"
           >
             <Trash2 size={16} />
@@ -130,6 +134,8 @@ const UniverseCreator = () => {
         <div className="flex gap-2">
           <button
             onClick={() => setSelectedLocation(location)}
+            title="Editar local"
+            aria-label="Editar local"
             className="text-blue-500 hover:text-blue-700"
           >
             <Edit size={16} />
@@ -138,6 +144,8 @@ const UniverseCreator = () => {
             onClick={() => {
               removeLocation(location.id);
             }}
+            title="Remover local"
+            aria-label="Remover local"
             className="text-red-500 hover:text-red-700"
           >
             <Trash2 size={16} />
@@ -230,10 +238,20 @@ const UniverseCreator = () => {
       <div className="flex justify-between items-start mb-4">
         <h3 className="text-xl font-bold">{economy.name}</h3>
         <div className="flex gap-2">
-          <button onClick={() => setSelectedEconomy(economy)} className="text-blue-500 hover:text-blue-700">
+          <button
+            onClick={() => setSelectedEconomy(economy)}
+            title="Editar economia"
+            aria-label="Editar economia"
+            className="text-blue-500 hover:text-blue-700"
+          >
             <Edit size={16} />
           </button>
-          <button onClick={() => removeEconomy(economy.id)} className="text-red-500 hover:text-red-700">
+          <button
+            onClick={() => removeEconomy(economy.id)}
+            title="Remover economia"
+            aria-label="Remover economia"
+            className="text-red-500 hover:text-red-700"
+          >
             <Trash2 size={16} />
           </button>
         </div>
@@ -251,10 +269,20 @@ const UniverseCreator = () => {
       <div className="flex justify-between items-start mb-4">
         <h3 className="text-xl font-bold">{religion.name}</h3>
         <div className="flex gap-2">
-          <button onClick={() => setSelectedReligion(religion)} className="text-blue-500 hover:text-blue-700">
+          <button
+            onClick={() => setSelectedReligion(religion)}
+            title="Editar religião"
+            aria-label="Editar religião"
+            className="text-blue-500 hover:text-blue-700"
+          >
             <Edit size={16} />
           </button>
-          <button onClick={() => removeReligion(religion.id)} className="text-red-500 hover:text-red-700">
+          <button
+            onClick={() => removeReligion(religion.id)}
+            title="Remover religião"
+            aria-label="Remover religião"
+            className="text-red-500 hover:text-red-700"
+          >
             <Trash2 size={16} />
           </button>
         </div>
@@ -271,10 +299,20 @@ const UniverseCreator = () => {
       <div className="flex justify-between items-start mb-4">
         <h3 className="text-xl font-bold">{event.title}</h3>
         <div className="flex gap-2">
-          <button onClick={() => setSelectedTimeline(event)} className="text-blue-500 hover:text-blue-700">
+          <button
+            onClick={() => setSelectedTimeline(event)}
+            title="Editar evento"
+            aria-label="Editar evento"
+            className="text-blue-500 hover:text-blue-700"
+          >
             <Edit size={16} />
           </button>
-          <button onClick={() => removeTimeline(event.id)} className="text-red-500 hover:text-red-700">
+          <button
+            onClick={() => removeTimeline(event.id)}
+            title="Remover evento"
+            aria-label="Remover evento"
+            className="text-red-500 hover:text-red-700"
+          >
             <Trash2 size={16} />
           </button>
         </div>
@@ -292,10 +330,20 @@ const UniverseCreator = () => {
       <div className="flex justify-between items-start mb-4">
         <h3 className="text-xl font-bold">{language.name}</h3>
         <div className="flex gap-2">
-          <button onClick={() => setSelectedLanguage(language)} className="text-blue-500 hover:text-blue-700">
+          <button
+            onClick={() => setSelectedLanguage(language)}
+            title="Editar língua"
+            aria-label="Editar língua"
+            className="text-blue-500 hover:text-blue-700"
+          >
             <Edit size={16} />
           </button>
-          <button onClick={() => removeLanguage(language.id)} className="text-red-500 hover:text-red-700">
+          <button
+            onClick={() => removeLanguage(language.id)}
+            title="Remover língua"
+            aria-label="Remover língua"
+            className="text-red-500 hover:text-red-700"
+          >
             <Trash2 size={16} />
           </button>
         </div>


### PR DESCRIPTION
## Summary
- add tooltip and accessibility labels to sidebar toggle
- show tooltips for shell navigation tabs
- provide descriptive titles for edit and delete controls in universe creator views

## Testing
- `npm run typecheck` *(fails: Cannot find module 'sql.js' and numerous type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b5983774ac8325b1cc67729166a2e2