### PR TITLE
feat: add stats panel with charts

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "@radix-ui/react-slot": "^1.0.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
-    "tailwind-merge": "^2.3.0"
+    "tailwind-merge": "^2.3.0",
+    "chart.js": "^4.4.0",
+    "react-chartjs-2": "^5.2.0"
   },
   "devDependencies": {
     "@types/react": "^19.1.12",

--- a/src/components/StatsPanel.tsx
+++ b/src/components/StatsPanel.tsx
@@ -1,0 +1,102 @@
+// @ts-nocheck
+import React, { useState, useMemo } from 'react';
+import { Pie, Bar } from 'react-chartjs-2';
+import {
+  Chart as ChartJS,
+  ArcElement,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { getTotalPopulation, getTotalArmySize } from '../utils/stats';
+
+ChartJS.register(ArcElement, BarElement, CategoryScale, LinearScale, Tooltip, Legend);
+
+const StatsPanel = ({ characters, locations, onClose }) => {
+  const [roleFilter, setRoleFilter] = useState('all');
+  const [typeFilter, setTypeFilter] = useState('all');
+
+  const roleOptions = useMemo(() => Array.from(new Set(characters.map(c => c.role))), [characters]);
+  const typeOptions = useMemo(() => Array.from(new Set(locations.map(l => l.type))), [locations]);
+
+  const filteredCharacters = useMemo(
+    () => (roleFilter === 'all' ? characters : characters.filter(c => c.role === roleFilter)),
+    [characters, roleFilter]
+  );
+  const filteredLocations = useMemo(
+    () => (typeFilter === 'all' ? locations : locations.filter(l => l.type === typeFilter)),
+    [locations, typeFilter]
+  );
+
+  const roleLabels = Array.from(new Set(filteredCharacters.map(c => c.role)));
+  const roleCounts = roleLabels.map(role => filteredCharacters.filter(c => c.role === role).length);
+
+  const typeLabels = Array.from(new Set(filteredLocations.map(l => l.type)));
+  const typeCounts = typeLabels.map(type => filteredLocations.filter(l => l.type === type).length);
+
+  const populationLabels = filteredLocations.map(l => l.name);
+  const populationData = filteredLocations.map(l => l.population || 0);
+
+  const armyLabels = filteredLocations.map(l => l.name);
+  const armyData = filteredLocations.map(l => l.army?.size || 0);
+
+  const totalPopulation = getTotalPopulation(filteredLocations);
+  const totalArmy = getTotalArmySize(filteredLocations);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white rounded-lg p-6 max-w-5xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-xl font-bold">Estatísticas do Universo</h2>
+          <button onClick={onClose} className="text-gray-500 hover:text-gray-700">✖</button>
+        </div>
+
+        <div className="flex gap-4 mb-6">
+          <div>
+            <label className="block text-sm mb-1">Tipo de personagem</label>
+            <select value={roleFilter} onChange={e => setRoleFilter(e.target.value)} className="border rounded px-2 py-1">
+              <option value="all">Todos</option>
+              {roleOptions.map(role => (
+                <option key={role} value={role}>{role}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm mb-1">Região</label>
+            <select value={typeFilter} onChange={e => setTypeFilter(e.target.value)} className="border rounded px-2 py-1">
+              <option value="all">Todas</option>
+              {typeOptions.map(type => (
+                <option key={type} value={type}>{type}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <h3 className="font-semibold mb-2">Personagens por Papel</h3>
+            <Pie data={{ labels: roleLabels, datasets: [{ data: roleCounts, backgroundColor: roleLabels.map((_, i) => `hsl(${(i * 60) % 360},70%,60%)`) }] }} />
+          </div>
+          <div>
+            <h3 className="font-semibold mb-2">Localizações por Tipo</h3>
+            <Pie data={{ labels: typeLabels, datasets: [{ data: typeCounts, backgroundColor: typeLabels.map((_, i) => `hsl(${(i * 60) % 360},70%,60%)`) }] }} />
+          </div>
+          <div>
+            <h3 className="font-semibold mb-2">População por Local</h3>
+            <Bar data={{ labels: populationLabels, datasets: [{ label: 'População', data: populationData, backgroundColor: '#36A2EB' }] }} />
+            <p className="text-sm mt-2">População total: {totalPopulation.toLocaleString()}</p>
+          </div>
+          <div>
+            <h3 className="font-semibold mb-2">Força Militar por Local</h3>
+            <Bar data={{ labels: armyLabels, datasets: [{ label: 'Exército', data: armyData, backgroundColor: '#FF6384' }] }} />
+            <p className="text-sm mt-2">Força militar total: {totalArmy.toLocaleString()}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StatsPanel;

--- a/src/universeCreator.tsx
+++ b/src/universeCreator.tsx
@@ -15,6 +15,7 @@ import { useTimelines } from './hooks/useTimelines';
 import { useLanguages } from './hooks/useLanguages';
 import { useTheme } from './ui/ThemeProvider';
 import './tokens.css';
+import StatsPanel from './components/StatsPanel';
 
 const UniverseCreator = () => {
   const [activeTab, setActiveTab] = useState('characters');
@@ -38,6 +39,7 @@ const UniverseCreator = () => {
   const [showReligionForm, setShowReligionForm] = useState(false);
   const [showTimelineForm, setShowTimelineForm] = useState(false);
   const [showLanguageForm, setShowLanguageForm] = useState(false);
+  const [showStatsPanel, setShowStatsPanel] = useState(false);
   const [expandedSections, setExpandedSections] = useState({});
 
   
@@ -957,11 +959,7 @@ const UniverseCreator = () => {
         </button>
 
         <button
-          onClick={() => {
-            const totalPop = locations.reduce((total, loc) => total + (loc.population || 0), 0);
-            const totalArmy = locations.reduce((total, loc) => total + (loc.army?.size || 0), 0);
-            alert(`Resumo do Universo:\n\n• Personagens: ${characters.length}\n• Localizações: ${locations.length}\n• População Total: ${totalPop.toLocaleString()}\n• Força Militar: ${totalArmy.toLocaleString()}`);
-          }}
+          onClick={() => setShowStatsPanel(true)}
           className="bg-purple-500 text-white p-3 rounded-full shadow-token hover:bg-purple-600 transition-colors"
           title="Resumo Rápido"
         >
@@ -1035,6 +1033,14 @@ const UniverseCreator = () => {
             setSelectedLanguage(null);
             setShowLanguageForm(false);
           }}
+        />
+      )}
+
+      {showStatsPanel && (
+        <StatsPanel
+          characters={characters}
+          locations={locations}
+          onClose={() => setShowStatsPanel(false)}
         />
       )}
     </main>

--- a/src/utils/stats.ts
+++ b/src/utils/stats.ts
@@ -1,0 +1,7 @@
+export function getTotalPopulation(locations: { population?: number }[]) {
+  return locations.reduce((total, loc) => total + (loc.population || 0), 0);
+}
+
+export function getTotalArmySize(locations: { army?: { size?: number } }[]) {
+  return locations.reduce((total, loc) => total + (loc.army?.size || 0), 0);
+}


### PR DESCRIPTION
## Summary
- add chart.js and react-chartjs-2 dependencies
- create StatsPanel with filters and charts for characters and locations
- open StatsPanel from UniverseCreator and reuse population/army utilities

## Testing
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run typecheck` *(fails: missing type declarations and modules)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bec8ae048325a5d1bd3410eb9739