### PR TITLE
feat: add entity relations graph

### DIFF
--- a/src/components/EntityRelationsGraph.tsx
+++ b/src/components/EntityRelationsGraph.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+
+interface Character {
+  id: number;
+  name: string;
+  locationIds?: number[];
+  religionIds?: number[];
+  relationships?: string;
+}
+
+interface Location {
+  id: number;
+  name: string;
+  characterIds?: number[];
+  religions?: string[];
+}
+
+interface Religion {
+  id: number;
+  name: string;
+  characterIds?: number[];
+}
+
+interface Props {
+  characters: Character[];
+  locations: Location[];
+  religions: Religion[];
+  selectedCharacter?: Character | null;
+  selectedLocation?: Location | null;
+}
+
+const EntityRelationsGraph: React.FC<Props> = ({
+  characters,
+  locations,
+  religions,
+  selectedCharacter,
+  selectedLocation,
+}) => {
+  if (!selectedCharacter && !selectedLocation) return null;
+
+  if (selectedCharacter) {
+    const linkedLocations = locations.filter((l) =>
+      selectedCharacter.locationIds?.includes(l.id)
+    );
+    const linkedReligions = religions.filter((r) =>
+      selectedCharacter.religionIds?.includes(r.id)
+    );
+    const relatedCharacters = selectedCharacter.relationships
+      ? characters.filter((c) =>
+          selectedCharacter.relationships!
+            .split(',')
+            .map((s) => s.trim().toLowerCase())
+            .includes(c.name.toLowerCase())
+        )
+      : [];
+
+    return (
+      <section className="rounded-lg p-6 bg-panel shadow-token mt-4">
+        <h3 className="text-xl font-bold mb-4">
+          Relações de {selectedCharacter.name}
+        </h3>
+        <div className="space-y-2 text-sm">
+          {relatedCharacters.length > 0 && (
+            <p>
+              <span className="font-semibold">Personagens:</span>{' '}
+              {relatedCharacters.map((c) => c.name).join(', ')}
+            </p>
+          )}
+          {linkedLocations.length > 0 && (
+            <p>
+              <span className="font-semibold">Localizações:</span>{' '}
+              {linkedLocations.map((l) => l.name).join(', ')}
+            </p>
+          )}
+          {linkedReligions.length > 0 && (
+            <p>
+              <span className="font-semibold">Religiões:</span>{' '}
+              {linkedReligions.map((r) => r.name).join(', ')}
+            </p>
+          )}
+          {relatedCharacters.length === 0 &&
+            linkedLocations.length === 0 &&
+            linkedReligions.length === 0 && <p>Nenhuma relação encontrada.</p>}
+        </div>
+      </section>
+    );
+  }
+
+  if (selectedLocation) {
+    const linkedCharacters = characters.filter((c) =>
+      c.locationIds?.includes(selectedLocation.id)
+    );
+    const locationReligions =
+      selectedLocation.religions && selectedLocation.religions.length > 0
+        ? selectedLocation.religions
+        : religions
+            .filter((r) =>
+              linkedCharacters.some((c) => c.religionIds?.includes(r.id))
+            )
+            .map((r) => r.name);
+
+    return (
+      <section className="rounded-lg p-6 bg-panel shadow-token mt-4">
+        <h3 className="text-xl font-bold mb-4">
+          Relações de {selectedLocation.name}
+        </h3>
+        <div className="space-y-2 text-sm">
+          {linkedCharacters.length > 0 && (
+            <p>
+              <span className="font-semibold">Personagens:</span>{' '}
+              {linkedCharacters.map((c) => c.name).join(', ')}
+            </p>
+          )}
+          {locationReligions.length > 0 && (
+            <p>
+              <span className="font-semibold">Religiões:</span>{' '}
+              {locationReligions.join(', ')}
+            </p>
+          )}
+          {linkedCharacters.length === 0 &&
+            locationReligions.length === 0 && <p>Nenhuma relação encontrada.</p>}
+        </div>
+      </section>
+    );
+  }
+
+  return null;
+};
+
+export default EntityRelationsGraph;

--- a/src/universeCreator.tsx
+++ b/src/universeCreator.tsx
@@ -15,6 +15,7 @@ import { useTimelines } from './hooks/useTimelines';
 import { useLanguages } from './hooks/useLanguages';
 import { useTheme } from './ui/ThemeProvider';
 import './tokens.css';
+import EntityRelationsGraph from './components/EntityRelationsGraph';
 
 const UniverseCreator = () => {
   const [activeTab, setActiveTab] = useState('characters');
@@ -968,6 +969,16 @@ const UniverseCreator = () => {
           <BarChart3 size={20} />
         </button>
       </div>
+
+      {(selectedCharacter || selectedLocation) && (
+        <EntityRelationsGraph
+          characters={characters}
+          locations={locations}
+          religions={religions}
+          selectedCharacter={selectedCharacter}
+          selectedLocation={selectedLocation}
+        />
+      )}
 
       {/* Modais */}
       {(showCharacterForm || selectedCharacter) && (


### PR DESCRIPTION
## Summary
- add EntityRelationsGraph component to show relationships between characters, locations and religions
- integrate EntityRelationsGraph into UniverseCreator and display when selecting a character or location

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run typecheck` (fails: TS errors in editor and ui components)


------
https://chatgpt.com/codex/tasks/task_e_68b5becc23cc83259060832fe0b8bc75