### PR TITLE
feat: link characters with locations and religions

### DIFF
--- a/src/universe/CharacterForm.tsx
+++ b/src/universe/CharacterForm.tsx
@@ -1,6 +1,8 @@
 // @ts-nocheck
 import React, { useState } from 'react';
 import '../tokens.css';
+import { useLocations } from '../hooks/useLocations';
+import { useReligions } from '../hooks/useReligions';
 
 interface CharacterFormProps {
   character: any;
@@ -20,13 +22,22 @@ const CharacterForm = ({ character, onSave, onCancel }: CharacterFormProps) => {
     role: ''
   });
   const [errors, setErrors] = useState({ name: '' });
+  const { locations } = useLocations();
+  const { religions } = useReligions();
+  const [selectedLocations, setSelectedLocations] = useState<number[]>(character?.locationIds || []);
+  const [selectedReligions, setSelectedReligions] = useState<number[]>(character?.religionIds || []);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const newErrors = { name: formData.name.trim() ? '' : 'Nome é obrigatório' };
     setErrors(newErrors);
     if (Object.values(newErrors).some(Boolean)) return;
-    onSave({ ...formData, id: character?.id || Date.now() });
+    onSave({
+      ...formData,
+      id: character?.id || Date.now(),
+      locationIds: selectedLocations,
+      religionIds: selectedReligions,
+    });
   };
 
   return (
@@ -116,6 +127,46 @@ const CharacterForm = ({ character, onSave, onCancel }: CharacterFormProps) => {
               onChange={(e) => setFormData({ ...formData, role: e.target.value })}
               className="border rounded px-3 py-2 w-full"
             />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="char-locations" className="mb-1 text-sm">Localizações</label>
+            <select
+              id="char-locations"
+              multiple
+              value={selectedLocations.map(String)}
+              onChange={(e) =>
+                setSelectedLocations(
+                  Array.from(e.target.selectedOptions, (option) => Number(option.value))
+                )
+              }
+              className="border rounded px-3 py-2 w-full"
+            >
+              {locations.map((loc) => (
+                <option key={loc.id} value={loc.id}>
+                  {loc.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="char-religions" className="mb-1 text-sm">Religiões</label>
+            <select
+              id="char-religions"
+              multiple
+              value={selectedReligions.map(String)}
+              onChange={(e) =>
+                setSelectedReligions(
+                  Array.from(e.target.selectedOptions, (option) => Number(option.value))
+                )
+              }
+              className="border rounded px-3 py-2 w-full"
+            >
+              {religions.map((rel) => (
+                <option key={rel.id} value={rel.id}>
+                  {rel.name}
+                </option>
+              ))}
+            </select>
           </div>
           <div className="flex gap-2 pt-4">
             <button

--- a/src/universe/LocationForm.tsx
+++ b/src/universe/LocationForm.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import React, { useState } from 'react';
 import '../tokens.css';
+import { useCharacters } from '../hooks/useCharacters';
 
 interface LocationFormProps {
   location: any;
@@ -34,13 +35,19 @@ const LocationForm = ({ location, onSave, onCancel, generatePopulation, generate
     events: ''
   });
   const [errors, setErrors] = useState({ name: '' });
+  const { characters } = useCharacters();
+  const [selectedCharacters, setSelectedCharacters] = useState<number[]>(location?.characterIds || []);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const newErrors = { name: formData.name.trim() ? '' : 'Nome é obrigatório' };
     setErrors(newErrors);
     if (Object.values(newErrors).some(Boolean)) return;
-    onSave({ ...formData, id: location?.id || Date.now() });
+    onSave({
+      ...formData,
+      id: location?.id || Date.now(),
+      characterIds: selectedCharacters,
+    });
   };
 
   const handleArrayChange = (field: string, value: string) => {
@@ -288,22 +295,46 @@ const LocationForm = ({ location, onSave, onCancel, generatePopulation, generate
                 />
               </div>
             </div>
-            <div className="flex flex-col mt-2">
-              <label htmlFor="loc-events" className="mb-1 text-sm">Eventos importantes</label>
-              <textarea
-                id="loc-events"
-                placeholder="Eventos importantes"
-                value={formData.events}
-                onChange={(e) => setFormData({ ...formData, events: e.target.value })}
-                className="border rounded px-3 py-2 w-full h-20"
-              />
-            </div>
+          <div className="flex flex-col mt-2">
+            <label htmlFor="loc-events" className="mb-1 text-sm">Eventos importantes</label>
+            <textarea
+              id="loc-events"
+              placeholder="Eventos importantes"
+              value={formData.events}
+              onChange={(e) => setFormData({ ...formData, events: e.target.value })}
+              className="border rounded px-3 py-2 w-full h-20"
+            />
           </div>
+        </div>
 
-          <div className="flex gap-2 pt-4">
-            <button
-              type="submit"
-              className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
+        <div className="pb-4">
+          <h4 className="font-semibold mb-3">Personagens</h4>
+          <div className="flex flex-col">
+            <label htmlFor="loc-characters" className="mb-1 text-sm">Personagens</label>
+            <select
+              id="loc-characters"
+              multiple
+              value={selectedCharacters.map(String)}
+              onChange={(e) =>
+                setSelectedCharacters(
+                  Array.from(e.target.selectedOptions, (option) => Number(option.value))
+                )
+              }
+              className="border rounded px-3 py-2 w-full"
+            >
+              {characters.map((char) => (
+                <option key={char.id} value={char.id}>
+                  {char.name}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div className="flex gap-2 pt-4">
+          <button
+            type="submit"
+            className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600"
             >
               Salvar
             </button>

--- a/src/universe/ReligionForm.tsx
+++ b/src/universe/ReligionForm.tsx
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import React, { useState } from 'react';
 import '../tokens.css';
+import { useCharacters } from '../hooks/useCharacters';
 
 interface ReligionFormProps {
   religion: any;
@@ -17,13 +18,19 @@ const ReligionForm = ({ religion, onSave, onCancel }: ReligionFormProps) => {
     }
   );
   const [errors, setErrors] = useState({ name: '' });
+  const { characters } = useCharacters();
+  const [selectedCharacters, setSelectedCharacters] = useState<number[]>(religion?.characterIds || []);
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const newErrors = { name: formData.name.trim() ? '' : 'Nome é obrigatório' };
     setErrors(newErrors);
     if (Object.values(newErrors).some(Boolean)) return;
-    onSave({ ...formData, id: religion?.id || Date.now() });
+    onSave({
+      ...formData,
+      id: religion?.id || Date.now(),
+      characterIds: selectedCharacters,
+    });
   };
 
   return (
@@ -65,6 +72,26 @@ const ReligionForm = ({ religion, onSave, onCancel }: ReligionFormProps) => {
               onChange={(e) => setFormData({ ...formData, factions: e.target.value })}
               className="border rounded px-3 py-2 w-full"
             />
+          </div>
+          <div className="flex flex-col">
+            <label htmlFor="religion-characters" className="mb-1 text-sm">Personagens</label>
+            <select
+              id="religion-characters"
+              multiple
+              value={selectedCharacters.map(String)}
+              onChange={(e) =>
+                setSelectedCharacters(
+                  Array.from(e.target.selectedOptions, (option) => Number(option.value))
+                )
+              }
+              className="border rounded px-3 py-2 w-full"
+            >
+              {characters.map((char) => (
+                <option key={char.id} value={char.id}>
+                  {char.name}
+                </option>
+              ))}
+            </select>
           </div>
           <div className="flex gap-2 pt-4">
             <button

--- a/src/universeCreator.tsx
+++ b/src/universeCreator.tsx
@@ -18,10 +18,30 @@ import './tokens.css';
 
 const UniverseCreator = () => {
   const [activeTab, setActiveTab] = useState('characters');
-  const { characters, saveCharacter, removeCharacter } = useCharacters();
-  const { locations, saveLocation, removeLocation } = useLocations();
+  const {
+    characters,
+    saveCharacter,
+    removeCharacter,
+    linkCharacterToLocation,
+    unlinkCharacterFromLocation,
+    linkCharacterToReligion,
+    unlinkCharacterFromReligion,
+  } = useCharacters();
+  const {
+    locations,
+    saveLocation,
+    removeLocation,
+    linkLocationToCharacter,
+    unlinkLocationFromCharacter,
+  } = useLocations();
   const { economies, saveEconomy, removeEconomy } = useEconomies();
-  const { religions, saveReligion, removeReligion } = useReligions();
+  const {
+    religions,
+    saveReligion,
+    removeReligion,
+    linkReligionToCharacter,
+    unlinkReligionFromCharacter,
+  } = useReligions();
   const { timelines, saveTimeline, removeTimeline } = useTimelines();
   const { languages, saveLanguage, removeLanguage } = useLanguages();
   const { theme } = useTheme();
@@ -365,12 +385,38 @@ const UniverseCreator = () => {
   // Handlers
   const handleSaveCharacter = async (characterData) => {
     await saveCharacter(characterData);
+    const charId = characterData.id;
+    const prevLocs = selectedCharacter?.locationIds || [];
+    const newLocs = characterData.locationIds || [];
+    for (const id of newLocs.filter((id) => !prevLocs.includes(id))) {
+      await linkCharacterToLocation(charId, id);
+    }
+    for (const id of prevLocs.filter((id) => !newLocs.includes(id))) {
+      await unlinkCharacterFromLocation(charId, id);
+    }
+    const prevRels = selectedCharacter?.religionIds || [];
+    const newRels = characterData.religionIds || [];
+    for (const id of newRels.filter((id) => !prevRels.includes(id))) {
+      await linkCharacterToReligion(charId, id);
+    }
+    for (const id of prevRels.filter((id) => !newRels.includes(id))) {
+      await unlinkCharacterFromReligion(charId, id);
+    }
     setSelectedCharacter(null);
     setShowCharacterForm(false);
   };
 
   const handleSaveLocation = async (locationData) => {
     await saveLocation(locationData);
+    const locId = locationData.id;
+    const prevChars = selectedLocation?.characterIds || [];
+    const newChars = locationData.characterIds || [];
+    for (const id of newChars.filter((id) => !prevChars.includes(id))) {
+      await linkLocationToCharacter(locId, id);
+    }
+    for (const id of prevChars.filter((id) => !newChars.includes(id))) {
+      await unlinkLocationFromCharacter(locId, id);
+    }
     setSelectedLocation(null);
     setShowLocationForm(false);
   };
@@ -383,6 +429,15 @@ const UniverseCreator = () => {
 
   const handleSaveReligion = async (religionData) => {
     await saveReligion(religionData);
+    const relId = religionData.id;
+    const prevChars = selectedReligion?.characterIds || [];
+    const newChars = religionData.characterIds || [];
+    for (const id of newChars.filter((id) => !prevChars.includes(id))) {
+      await linkReligionToCharacter(relId, id);
+    }
+    for (const id of prevChars.filter((id) => !newChars.includes(id))) {
+      await unlinkReligionFromCharacter(relId, id);
+    }
     setSelectedReligion(null);
     setShowReligionForm(false);
   };


### PR DESCRIPTION
## Summary
- add multi-select of locations and religions to character form
- allow linking characters to locations and religions when saving
- expose character linking in location and religion forms

## Testing
- `npm run typecheck` *(fails: Binding element 'setNewRelation' implicitly has an 'any' type, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68b5bf05a5208325a7da8c30099bfd97