### PR TITLE
feat: add testing framework and basic tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest"
   },
   "repository": {
     "type": "git",
@@ -46,6 +47,10 @@
     "vite": "^7.1.3",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.38",
-    "tailwindcss": "^3.4.4"
+    "tailwindcss": "^3.4.4",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "fake-indexeddb": "^5.0.1"
   }
 }

--- a/tests/StatsPanel.test.tsx
+++ b/tests/StatsPanel.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import StatsPanel from '../src/components/StatsPanel';
+
+vi.mock('react-chartjs-2', () => ({
+  Pie: () => <div data-testid="pie-chart" />,
+  Bar: () => <div data-testid="bar-chart" />,
+}));
+
+const characters = [
+  { role: 'hero' },
+  { role: 'villain' },
+  { role: 'hero' },
+];
+
+const locations = [
+  { name: 'City', type: 'urban', population: 1000, army: { size: 100 } },
+  { name: 'Forest', type: 'rural', population: 200, army: { size: 20 } },
+];
+
+describe('StatsPanel', () => {
+  it('renders total statistics', () => {
+    const onClose = vi.fn();
+    render(<StatsPanel characters={characters} locations={locations} onClose={onClose} />);
+    const totalPopulation = (1000 + 200).toLocaleString();
+    const totalArmy = (100 + 20).toLocaleString();
+    expect(screen.getByText(`População total: ${totalPopulation}`)).toBeInTheDocument();
+    expect(screen.getByText(`Força militar total: ${totalArmy}`)).toBeInTheDocument();
+  });
+
+  it('allows filtering by character role', () => {
+    const onClose = vi.fn();
+    render(<StatsPanel characters={characters} locations={locations} onClose={onClose} />);
+    const roleSelect = screen.getByLabelText('Tipo de personagem');
+    fireEvent.change(roleSelect, { target: { value: 'villain' } });
+    expect((roleSelect as HTMLSelectElement).value).toBe('villain');
+  });
+});

--- a/tests/dataStore.test.ts
+++ b/tests/dataStore.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { getCharacters, saveCharacter, removeCharacter } from '../dataStore';
+
+beforeEach(async () => {
+  await new Promise<void>((resolve) => {
+    const req = indexedDB.deleteDatabase('loreloom_db');
+    req.onsuccess = () => resolve();
+    req.onerror = () => resolve();
+  });
+});
+
+describe('dataStore', () => {
+  it('saves and retrieves characters', async () => {
+    let chars = await getCharacters();
+    expect(chars).toEqual([]);
+
+    await saveCharacter({ id: 1, name: 'Alice', description: 'Heroine', role: 'hero' });
+    chars = await getCharacters();
+    expect(chars).toEqual([
+      { id: 1, name: 'Alice', description: 'Heroine', role: 'hero' },
+    ]);
+
+    await removeCharacter(1);
+    chars = await getCharacters();
+    expect(chars).toEqual([]);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,5 +13,9 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
     },
   },
+  test: {
+    environment: 'jsdom',
+    setupFiles: './vitest.setup.ts',
+  },
 });
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,8 @@
+import '@testing-library/jest-dom';
+import 'fake-indexeddb/auto';
+
+if (typeof window !== 'undefined') {
+  // Ensure fake-indexeddb is available via window
+  // @ts-ignore
+  window.indexedDB = indexedDB;
+}


### PR DESCRIPTION
## Summary
- add vitest and testing library setup
- add tests for data store and stats panel components
- run tests in CI workflow

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5da67878c8325a727b15d9eb43f44