### PR TITLE
Add admin user management page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,10 +6,31 @@ import logoUrl from '../assets/logo.png';
 import { Routes, Route, Link, useLocation, Navigate } from 'react-router-dom';
 import './tokens.css';
 import { Button } from '@/components/ui/button';
+import { useAuth } from './context/AuthContext';
+import UserManagement from '@/pages/UserManagement';
+
+function AdminRoute({ children }: { children: React.ReactNode }) {
+  const { isAdminMaster, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center p-6 text-sm text-muted">
+        Carregando permissões...
+      </div>
+    );
+  }
+
+  if (!isAdminMaster) {
+    return <Navigate to="/editor" replace />;
+  }
+
+  return <>{children}</>;
+}
 
 const App = () => {
   const location = useLocation();
   const currentPath = location.pathname === '/' ? '/editor' : location.pathname;
+  const { isAdminMaster, loading } = useAuth();
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -34,6 +55,14 @@ const App = () => {
           >
             <Link to="/universo">Universo</Link>
           </Button>
+          {!loading && isAdminMaster ? (
+            <Button
+              asChild
+              variant={currentPath === '/usuarios' ? 'secondary' : 'ghost'}
+            >
+              <Link to="/usuarios">Usuários</Link>
+            </Button>
+          ) : null}
           <ThemeToggle />
         </nav>
       </header>
@@ -42,6 +71,14 @@ const App = () => {
           <Route path="/" element={<Navigate to="/editor" replace />} />
           <Route path="/editor" element={<FictionEditor />} />
           <Route path="/universo" element={<UniverseCreator />} />
+          <Route
+            path="/usuarios"
+            element={
+              <AdminRoute>
+                <UserManagement />
+              </AdminRoute>
+            }
+          />
         </Routes>
       </main>
     </div>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          "flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = "Input";
+
+export { Input };

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Label = React.forwardRef<
+  HTMLLabelElement,
+  React.LabelHTMLAttributes<HTMLLabelElement>
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn(
+      "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+      className,
+    )}
+    {...props}
+  />
+));
+Label.displayName = "Label";
+
+export { Label };

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Select = React.forwardRef<
+  HTMLSelectElement,
+  React.SelectHTMLAttributes<HTMLSelectElement>
+>(({ className, ...props }, ref) => (
+  <select
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  />
+));
+Select.displayName = "Select";
+
+export { Select };

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,117 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = "Table";
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+));
+TableBody.displayName = "TableBody";
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "bg-muted/50 font-medium text-foreground [&>tr]:last:border-b-0",
+      className,
+    )}
+    {...props}
+  />
+));
+TableFooter.displayName = "TableFooter";
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      className,
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-2 text-left align-middle font-medium text-muted [&:has([role=checkbox])]:pr-0",
+      className,
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("p-2 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+));
+TableCell.displayName = "TableCell";
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("mt-4 text-sm text-muted", className)}
+    {...props}
+  />
+));
+TableCaption.displayName = "TableCaption";
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+};

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -8,6 +8,7 @@ import {
   type ReactNode,
 } from 'react';
 import * as dataStore from '../../dataStore';
+import { hashPassword } from '@/utils/password';
 
 type AuthUser = dataStore.UserRecord;
 
@@ -26,25 +27,6 @@ const AUTH_STORAGE_KEY = 'loreloom.auth.userId';
 const DEFAULT_ADMIN_NAME = 'Admin Master';
 const DEFAULT_ADMIN_EMAIL = 'admin@loreloom.app';
 const DEFAULT_ADMIN_PASSWORD = 'admin_master';
-
-function getCrypto() {
-  if (typeof globalThis === 'undefined') {
-    return undefined;
-  }
-  return globalThis.crypto ?? undefined;
-}
-
-async function hashPassword(password: string) {
-  const cryptoInstance = getCrypto();
-  if (!cryptoInstance?.subtle) {
-    return password;
-  }
-  const data = new TextEncoder().encode(password);
-  const digest = await cryptoInstance.subtle.digest('SHA-256', data);
-  return Array.from(new Uint8Array(digest))
-    .map((byte) => byte.toString(16).padStart(2, '0'))
-    .join('');
-}
 
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);

--- a/src/pages/UserManagement.tsx
+++ b/src/pages/UserManagement.tsx
@@ -1,0 +1,334 @@
+import { useMemo, useState, type FormEvent } from 'react';
+
+import { useUsers } from '@/hooks/useUsers';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select } from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { hashPassword } from '@/utils/password';
+import { useAuth } from '@/context/AuthContext';
+import type { UserRecord } from '../../dataStore';
+
+interface FormState {
+  id?: number;
+  name: string;
+  email: string;
+  role: string;
+  password: string;
+}
+
+const ROLE_OPTIONS = [
+  { value: 'admin_master', label: 'Admin master' },
+  { value: 'editor', label: 'Editor' },
+  { value: 'writer', label: 'Autor' },
+  { value: 'viewer', label: 'Leitor' },
+];
+
+const DEFAULT_ROLE = 'editor';
+
+const INITIAL_FORM: FormState = {
+  id: undefined,
+  name: '',
+  email: '',
+  role: DEFAULT_ROLE,
+  password: '',
+};
+
+function getNextUserId(users: UserRecord[]): number {
+  if (users.length === 0) {
+    return 1;
+  }
+  return Math.max(...users.map((user) => user.id)) + 1;
+}
+
+const UserManagement = () => {
+  const { users, saveUser, removeUser } = useUsers();
+  const { user: currentUser, refreshUser } = useAuth();
+  const [formState, setFormState] = useState<FormState>(INITIAL_FORM);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const sortedUsers = useMemo(() => {
+    return [...users].sort((a, b) => a.id - b.id);
+  }, [users]);
+
+  const isEditing = typeof formState.id === 'number';
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatusMessage(null);
+    setErrorMessage(null);
+
+    const trimmedName = formState.name.trim();
+    const trimmedEmail = formState.email.trim();
+    const trimmedRole = formState.role.trim() || DEFAULT_ROLE;
+
+    if (!trimmedName || !trimmedEmail) {
+      setErrorMessage('Preencha nome e e-mail para salvar o usuário.');
+      return;
+    }
+
+    if (!isEditing && !formState.password) {
+      setErrorMessage('Senha é obrigatória para novos usuários.');
+      return;
+    }
+
+    const targetId = formState.id ?? getNextUserId(users);
+    const existingUser = users.find((user) => user.id === formState.id);
+
+    try {
+      const passwordHash = formState.password
+        ? await hashPassword(formState.password)
+        : existingUser?.passwordHash ?? '';
+
+      if (!passwordHash) {
+        setErrorMessage('Informe uma senha válida.');
+        return;
+      }
+
+      await saveUser({
+        id: targetId,
+        name: trimmedName,
+        email: trimmedEmail,
+        role: trimmedRole,
+        passwordHash,
+      });
+
+      await refreshUser();
+
+      setStatusMessage(isEditing ? 'Usuário atualizado com sucesso.' : 'Usuário criado com sucesso.');
+      setFormState({ ...INITIAL_FORM });
+    } catch (error) {
+      console.error('Erro ao salvar usuário', error);
+      setErrorMessage('Não foi possível salvar o usuário. Verifique os dados e tente novamente.');
+    }
+  };
+
+  const handleEdit = (user: UserRecord) => {
+    setFormState({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      role: user.role || DEFAULT_ROLE,
+      password: '',
+    });
+    setStatusMessage(null);
+    setErrorMessage(null);
+  };
+
+  const handleCancelEdit = () => {
+    setFormState({ ...INITIAL_FORM });
+    setStatusMessage(null);
+    setErrorMessage(null);
+  };
+
+  const handleDelete = async (user: UserRecord) => {
+    if (user.role === 'admin_master') {
+      setErrorMessage('O usuário admin master não pode ser removido.');
+      return;
+    }
+
+    if (!window.confirm(`Deseja realmente remover ${user.name}?`)) {
+      return;
+    }
+
+    try {
+      await removeUser(user.id);
+      if (currentUser?.id === user.id) {
+        await refreshUser();
+      }
+      if (formState.id === user.id) {
+        setFormState({ ...INITIAL_FORM });
+      }
+      setStatusMessage('Usuário removido com sucesso.');
+      setErrorMessage(null);
+    } catch (error) {
+      console.error('Erro ao remover usuário', error);
+      setErrorMessage('Não foi possível remover o usuário.');
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-8">
+      <header className="space-y-2">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-2xl font-semibold">Gerenciamento de usuários</h1>
+          <p className="text-sm text-muted">
+            Cadastre novos integrantes, atualize informações e defina perfis de acesso da equipe.
+          </p>
+        </div>
+        {statusMessage ? (
+          <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-800">
+            {statusMessage}
+          </div>
+        ) : null}
+        {errorMessage ? (
+          <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            {errorMessage}
+          </div>
+        ) : null}
+      </header>
+
+      <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1.25fr)]">
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-4 rounded-lg border border-border bg-panel p-5 shadow-sm"
+        >
+          <div>
+            <h2 className="text-lg font-medium">
+              {isEditing ? 'Editar usuário' : 'Adicionar novo usuário'}
+            </h2>
+            <p className="text-xs text-muted">
+              {isEditing
+                ? 'Atualize os dados e, se desejar, redefina a senha do integrante selecionado.'
+                : 'Preencha os dados para convidar alguém da equipe.'}
+            </p>
+          </div>
+
+          <div className="grid gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="user-name">Nome</Label>
+              <Input
+                id="user-name"
+                value={formState.name}
+                onChange={(event) =>
+                  setFormState((prev) => ({ ...prev, name: event.target.value }))
+                }
+                placeholder="Nome completo"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="user-email">E-mail</Label>
+              <Input
+                id="user-email"
+                type="email"
+                value={formState.email}
+                onChange={(event) =>
+                  setFormState((prev) => ({ ...prev, email: event.target.value }))
+                }
+                placeholder="nome@exemplo.com"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="user-role">Perfil de acesso</Label>
+              <Select
+                id="user-role"
+                value={formState.role}
+                onChange={(event) =>
+                  setFormState((prev) => ({ ...prev, role: event.target.value }))
+                }
+              >
+                {ROLE_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+                {!ROLE_OPTIONS.some((option) => option.value === formState.role) ? (
+                  <option value={formState.role}>{formState.role}</option>
+                ) : null}
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="user-password">
+                {isEditing ? 'Nova senha (opcional)' : 'Senha temporária'}
+              </Label>
+              <Input
+                id="user-password"
+                type="password"
+                value={formState.password}
+                onChange={(event) =>
+                  setFormState((prev) => ({ ...prev, password: event.target.value }))
+                }
+                placeholder={isEditing ? 'Deixe em branco para manter a atual' : 'Defina uma senha inicial'}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button type="submit">{isEditing ? 'Salvar alterações' : 'Criar usuário'}</Button>
+            {isEditing ? (
+              <Button type="button" variant="outline" onClick={handleCancelEdit}>
+                Cancelar edição
+              </Button>
+            ) : null}
+          </div>
+        </form>
+
+        <div className="rounded-lg border border-border bg-panel p-5 shadow-sm">
+          <div className="mb-4 flex items-center justify-between gap-2">
+            <div>
+              <h2 className="text-lg font-medium">Usuários cadastrados</h2>
+              <p className="text-xs text-muted">
+                Clique em “Editar” para ajustar dados ou em “Remover” para excluir alguém da equipe.
+              </p>
+            </div>
+            <Button type="button" variant="outline" onClick={() => setFormState({ ...INITIAL_FORM })}>
+              Novo cadastro
+            </Button>
+          </div>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="w-16">ID</TableHead>
+                <TableHead>Nome</TableHead>
+                <TableHead>E-mail</TableHead>
+                <TableHead className="w-40">Perfil</TableHead>
+                <TableHead className="w-36 text-right">Ações</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {sortedUsers.map((user) => (
+                <TableRow key={user.id}>
+                  <TableCell>{user.id}</TableCell>
+                  <TableCell className="font-medium">{user.name}</TableCell>
+                  <TableCell>{user.email}</TableCell>
+                  <TableCell>
+                    <span className="rounded-full bg-muted px-2 py-1 text-xs font-medium uppercase tracking-wide">
+                      {user.role || '—'}
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={() => handleEdit(user)}
+                      >
+                        Editar
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="text-red-600"
+                        onClick={() => handleDelete(user)}
+                        disabled={user.role === 'admin_master'}
+                      >
+                        Remover
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+            {sortedUsers.length === 0 ? (
+              <TableCaption>Nenhum usuário cadastrado até o momento.</TableCaption>
+            ) : null}
+          </Table>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+export default UserManagement;

--- a/src/utils/password.ts
+++ b/src/utils/password.ts
@@ -1,0 +1,18 @@
+export function getCrypto() {
+  if (typeof globalThis === 'undefined') {
+    return undefined;
+  }
+  return globalThis.crypto ?? undefined;
+}
+
+export async function hashPassword(password: string) {
+  const cryptoInstance = getCrypto();
+  if (!cryptoInstance?.subtle) {
+    return password;
+  }
+  const data = new TextEncoder().encode(password);
+  const digest = await cryptoInstance.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(digest))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+}


### PR DESCRIPTION
## Summary
- add reusable input, select, and table UI components plus a shared password hashing helper
- create an admin-only user management page backed by the useUsers hook
- protect the new /usuarios route with authentication context and expose navigation when allowed

## Testing
- npm run typecheck *(fails: existing TypeScript errors in worldgen module)*

------
https://chatgpt.com/codex/tasks/task_e_68cc493e9f708325b792374d89c1bbd3